### PR TITLE
NOTICK: build changes for vendor name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ boolean isEntReleaseBranch = (env.BRANCH_NAME =~ /^release\/ent\/.*/)
 boolean isOSReleaseTag = (env.BRANCH_NAME =~ /^release-OS-\/.*/)
 boolean isENTReleaseTag = (env.TAG_NAME =~ /^release-ENT-.*/) 
 
-def buildEdition = (isOSReleaseTag) ? "Corda Community Edition" : "Corda Open Source"#
+def buildEdition = (isOSReleaseTag) ? "Corda Community Edition" : "Corda Open Source"
 
 String artifactoryBuildName = "Corda-Shell"
 


### PR DESCRIPTION
Allows vender name to be set in accompanying logic in build.gradle 