### PR TITLE
ENT-6426 add credentials for ENT build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,6 @@ String mavenLocal = 'tmp/mavenlocal'
 
 def nexusDefaultIqStage = "build"
 
-
 /**
  * make sure calculated default value of NexusIQ stage is first in the list
  * thus making it default for the `choice` parameter


### PR DESCRIPTION
Artifactory credentials are needed for private ent repos, ensuring these are passed build from Jenkins