### PR TITLE
ENT-6536: minor update re regex for branch name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,8 +29,8 @@ boolean isRelease = (env.TAG_NAME =~ /^release-.*/)
 boolean isOSReleaseBranch = (env.BRANCH_NAME =~ /^release\/os\/.*/)
 boolean isEntReleaseBranch = (env.BRANCH_NAME =~ /^release\/ent\/.*/)
 
-boolean isOSReleaseTag = (env.BRANCH_NAME =~ /^release-OS-\/.*/)
-boolean isENTReleaseTag = (env.TAG_NAME =~ /^release-ENT-.*/) 
+boolean isOSReleaseTag = (env.BRANCH_NAME =~ /^release-OS-.*/)
+boolean isENTReleaseTag = (env.TAG_NAME =~ /^release-ENT-.*/)
 
 def buildEdition = "Corda Enterprise Edition"
 


### PR DESCRIPTION
fixing incorrect regex related to release branch naming in Jenkins file