### PR TITLE
ENT-6704 Separate standalone shell again

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 The Corda Shell is an application that allows the user to interact with a running Corda node.
 
-The shell can be used in two ways:
+The shell has 2 artifacts for each way that it can be used:
 
-- A standalone application - Run the `corda-shell` jar using:
+- A standalone application - Run the `corda-standalone-shell` jar using:
 
     ```shell
-     java -jar corda-shell-4.9.jar [-hvV] [--logging-level=<loggingLevel>] [--password=<password>]
+     java -jar corda-standalone-shell-4.9.jar [-hvV] [--logging-level=<loggingLevel>] [--password=<password>]
         [--truststore-file=<trustStoreFile>]
         [--truststore-password=<trustStorePassword>]
         [--truststore-type=<trustStoreType>] [--user=<user>] [-a=<host>]
@@ -31,6 +31,8 @@ The shell can be used in two ways:
     - `logging-level=<loggingLevel>`: Enable logging at this level and higher. Possible values: ERROR, WARN, INFO, DEBUG, TRACE. Default: INFO.
     - `help`, `-h`: Show this help message and exit.
     - `version`, `-V`: Print version information and exit.
+
+The `corda-shell` jar (not `corda-standalone-shell`) can still be used in as a standalone executable but will be missing any logging functionality.
     
 
 - A driver within a Corda node. Install the `corda-shell` jar in a node's `/drivers` directory to run the shell in the same terminal that starts the node. By default, a Corda node does not run the shell.

--- a/build.gradle
+++ b/build.gradle
@@ -184,7 +184,7 @@ bintrayConfig {
     projectUrl = 'https://github.com/corda/corda-shell'
     gpgSign = true
     gpgPassphrase = System.getenv('CORDA_BINTRAY_GPG_PASSPHRASE')
-    publications = ['corda-shell']
+    publications = ['corda-shell', 'corda-standalone-shell']
     license {
         name = 'Apache-2.0'
         url = 'https://www.apache.org/licenses/LICENSE-2.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'corda-shell'
 
 include 'shell'
+include 'standalone-shell'

--- a/shell/build.gradle
+++ b/shell/build.gradle
@@ -64,8 +64,6 @@ dependencies {
     // Manifests: for reading stuff from the manifest file.
     compile "com.jcabi:jcabi-manifests:1.1"
 
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
-
     // For logging, required for ANSIProgressRenderer.
     compile "org.apache.logging.log4j:log4j-core:$log4jVersion"
     compile "org.slf4j:jul-to-slf4j:$slf4jVersion"

--- a/standalone-shell/build.gradle
+++ b/standalone-shell/build.gradle
@@ -1,0 +1,59 @@
+plugins {
+    id 'com.github.johnrengelman.shadow' version '5.2.0' apply false
+}
+
+apply plugin: 'kotlin'
+apply plugin: 'java'
+apply plugin: 'application'
+apply plugin: 'net.corda.plugins.quasar-utils'
+apply plugin: 'net.corda.plugins.publish-utils'
+apply plugin: 'com.jfrog.artifactory'
+apply plugin: 'maven-publish'
+
+// We need to set mainClassName before applying the shadow plugin.
+mainClassName = 'net.corda.tools.shell.standalone.StandaloneShellKt'
+apply plugin: 'com.github.johnrengelman.shadow'
+
+description 'Corda Standalone Shell'
+
+configurations {
+    cordaShellDependencies {}
+}
+
+dependencies {
+    compile project(":shell")
+    compile files(project(":shell").sourceSets.main.output)
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+}
+
+tasks.withType(JavaCompile).configureEach {
+    // Resolves a Gradle warning about not scanning for pre-processors.
+    options.compilerArgs << '-proc:none'
+}
+
+jar {
+    enabled = false
+    archiveClassifier = 'ignore'
+}
+
+shadowJar {
+    archiveBaseName = 'corda-standalone-shell'
+    archiveClassifier = ''
+    mergeServiceFiles()
+    manifest {
+        attributes "Corda-Release-Version": cordaReleaseVersion
+        attributes('Corda-Platform-Version': cordaPlatformVersion)
+        attributes "Corda-Vendor": cordaBuildEdition
+    }
+}
+
+artifacts {
+    archives shadowJar
+    publish shadowJar
+}
+
+publish {
+    dependenciesFrom configurations.cordaShellDependencies
+    name shadowJar.archiveBaseName
+    disableDefaultJar = true
+}


### PR DESCRIPTION
Split the standalone shell into its own module again.

This is so when the shell is run embedded in a Corda node, there won't
be 2 implementations of SLF4J.

The embedded `corda-shell` and `corda-standalone-shell` jar will do the
same functionality wise, just one can log on its own and one cannot.

`corda-shell` will no longer log if run in a standalone manner, even though
it can be used this way. Instead, use the `corda-standalone-shell` if
logging is desired.