### PR TITLE
NOTICK update cron expression to only build for release branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
     }
 
     triggers {
-        cron '@midnight'
+        cron(isReleaseBranch ? '@midnight' : '')
     }
 
     environment {


### PR DESCRIPTION
cron job should only be triggered in the case of a release branch updating Jenkins logic to reflect this as this is causing build issues for tags created