### PR TITLE
NOTICK: skip Java doc task due to sporadic issues - blocking release 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,7 @@ pipeline {
                 script {
                         sh 'rm -rf $MAVEN_LOCAL_PUBLISH'
                         sh 'mkdir -p $MAVEN_LOCAL_PUBLISH'
-                        sh './gradlew publishToMavenLocal -Dmaven.repo.local="${MAVEN_LOCAL_PUBLISH}"' 
+                        sh './gradlew publishToMavenLocal -Dmaven.repo.local="${MAVEN_LOCAL_PUBLISH}" -x :shell:javadoc' 
                         sh 'ls -lR "${MAVEN_LOCAL_PUBLISH}"'
 
                     }
@@ -122,7 +122,7 @@ pipeline {
         stage('Build') {
             steps {
                 script{
-                    sh "./gradlew clean assemble -Si"
+                    sh "./gradlew clean assemble -Si -x :shell:javadoc"
                 }
             }
         }
@@ -176,7 +176,7 @@ pipeline {
                             rtGradleRun (
                                     usesPlugin: true,
                                     useWrapper: true,
-                                    switches: "--no-daemon -Si",
+                                    switches: "--no-daemon -Si -x :shell:javadoc",
                                     tasks: 'artifactoryPublish',
                                     deployerId: 'deployer',
                                     buildName: env.ARTIFACTORY_BUILD_NAME

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,8 @@ String mavenLocal = 'tmp/mavenlocal'
 
 def nexusDefaultIqStage = "build"
 
+def extraGradleCommands = '-x :shell:javadoc'
+
 
 /**
  * make sure calculated default value of NexusIQ stage is first in the list
@@ -83,7 +85,7 @@ pipeline {
                 script {
                         sh 'rm -rf $MAVEN_LOCAL_PUBLISH'
                         sh 'mkdir -p $MAVEN_LOCAL_PUBLISH'
-                        sh './gradlew publishToMavenLocal -Dmaven.repo.local="${MAVEN_LOCAL_PUBLISH}" -x :shell:javadoc' 
+                        sh "./gradlew publishToMavenLocal -Dmaven.repo.local=${MAVEN_LOCAL_PUBLISH} ${extraGradleCommands}" 
                         sh 'ls -lR "${MAVEN_LOCAL_PUBLISH}"'
 
                     }
@@ -122,7 +124,7 @@ pipeline {
         stage('Build') {
             steps {
                 script{
-                    sh "./gradlew clean assemble -Si -x :shell:javadoc"
+                    sh "./gradlew clean assemble -Si ${extraGradleCommands}"
                 }
             }
         }
@@ -176,7 +178,7 @@ pipeline {
                             rtGradleRun (
                                     usesPlugin: true,
                                     useWrapper: true,
-                                    switches: "--no-daemon -Si -x :shell:javadoc",
+                                    switches: "--no-daemon -Si ${extraGradleCommands}",
                                     tasks: 'artifactoryPublish',
                                     deployerId: 'deployer',
                                     buildName: env.ARTIFACTORY_BUILD_NAME


### PR DESCRIPTION
@nargas-ritu has previously confirmed with @adelel1 Java doc not needed for this Build.

This seems to be a very tricky to reproduce issue but has been hit on several shell releases, but rarely on CI. striping out task have confirmed not required.