### PR TITLE
NOTICK: set corda-remotes to allow us to leveraged Artifactory mirror of external repos on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,13 +65,14 @@ pipeline {
     }
 
     triggers {
-        cron '@midnight'
+        cron (isReleaseBranch ? '@midnight' : '')
     }
 
     environment {
         ARTIFACTORY_BUILD_NAME = "${artifactoryBuildName}"
         MAVEN_LOCAL_PUBLISH = "${env.WORKSPACE}/${mavenLocal}"
         CORDA_BUILD_EDITION = "${buildEdition}"
+        CORDA_USE_CACHE = "corda-remotes"
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,10 @@ pipeline {
 
     environment {
         ARTIFACTORY_BUILD_NAME = "${artifactoryBuildName}"
+        ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
         MAVEN_LOCAL_PUBLISH = "${env.WORKSPACE}/${mavenLocal}"
+        CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
+        CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
         CORDA_BUILD_EDITION = "${buildEdition}"
         CORDA_USE_CACHE = "corda-remotes"
     }


### PR DESCRIPTION
- add corda-remotes env var for repo mirroring
- ensure cron only runs on release branch's 