### PR TITLE
NOTICK: set corda-remotes to allow us to leveraged Artifactory mirror of external repos on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ pipeline {
     }
 
     triggers {
-        cron '@midnight'
+        cron (isReleaseBranch ? '@midnight' : '')
     }
 
     environment {
@@ -77,6 +77,7 @@ pipeline {
         ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
         CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
         CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
+        CORDA_USE_CACHE = "corda-remotes"
     }
 
     stages {


### PR DESCRIPTION
- add corda-remotes env var for repo mirroring
- ensure cron only runs on release branch's