### PR TITLE
INFRA-1909: add snyk scanning to corda-shell os project 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
         CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
         CORDA_BUILD_EDITION = "${buildEdition}"
         CORDA_USE_CACHE = "corda-remotes"
-        SNYK_TOKEN  = credentials('c4-os-snyk-api-token-secret')
+        SNYK_TOKEN  = credentials('c4-os-snyk-shell')
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,9 +122,9 @@ pipeline {
         }
 
         stage('Snyk Security') {
-            // when {
-            //     expression { isRelease || isReleaseBranch }
-            // }
+            when {
+                expression { isRelease || isReleaseBranch }
+            }
             steps {
                 script {
                     // Invoke Snyk for each Gradle sub project we wish to scan

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,9 +122,9 @@ pipeline {
         }
 
         stage('Snyk Security') {
-            when {
-                expression { isRelease || isReleaseBranch }
-            }
+            // when {
+            //     expression { isRelease || isReleaseBranch }
+            // }
             steps {
                 script {
                     // Invoke Snyk for each Gradle sub project we wish to scan

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
         CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
         CORDA_BUILD_EDITION = "${buildEdition}"
         CORDA_USE_CACHE = "corda-remotes"
-        SNYK_API_KEY = "c4-os-snyk-shell"
+        SNYK_TOKEN = "c4-os-snyk-shell"
     }
 
     stages {
@@ -130,7 +130,7 @@ pipeline {
                     // Invoke Snyk for each Gradle sub project we wish to scan
                     def modulesToScan = ['standalone-shell', 'shell']
                     modulesToScan.each { module ->
-                        snykSecurityScan(env.SNYK_API_KEY, "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'")
+                        snykSecurityScan(env.SNYK_TOKEN, "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'")
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
         CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
         CORDA_BUILD_EDITION = "${buildEdition}"
         CORDA_USE_CACHE = "corda-remotes"
-        SNYK_TOKEN  = credentials("c4-sdk-snyk")
+        SNYK_TOKEN  = credentials('c4-os-snyk-api-token-secret')
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
         CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
         CORDA_BUILD_EDITION = "${buildEdition}"
         CORDA_USE_CACHE = "corda-remotes"
-        SNYK_TOKEN  = credentials('c4-os-snyk-shell')
+        SNYK_API_KEY = "c4-os-snyk-shell"
     }
 
     stages {
@@ -130,7 +130,7 @@ pipeline {
                     // Invoke Snyk for each Gradle sub project we wish to scan
                     def modulesToScan = ['standalone-shell', 'shell']
                     modulesToScan.each { module ->
-                        snykSecurityScan(env.SNYK_TOKEN, "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'")
+                        snykSecurityScan(env.SNYK_API_KEY, "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'")
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,6 +76,7 @@ pipeline {
         CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
         CORDA_BUILD_EDITION = "${buildEdition}"
         CORDA_USE_CACHE = "corda-remotes"
+        SNYK_TOKEN  = credentials("c4-sdk-snyk")
     }
 
     stages {
@@ -118,6 +119,21 @@ pipeline {
                         )
                 }
              }
+        }
+
+        stage('Snyk Security') {
+            when {
+                expression { isRelease || isReleaseBranch }
+            }
+            steps {
+                script {
+                    // Invoke Snyk for each Gradle sub project we wish to scan
+                    def modulesToScan = ['standalone-shell', 'shell']
+                    modulesToScan.each { module ->
+                        snykSecurityScan(env.SNYK_TOKEN, "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'")
+                    }
+                }
+            }
         }
 
         stage('Build') {


### PR DESCRIPTION
Add standard Snyk scanning logic to the project CI leveraging shared lib.

Loop through modules to scan calling snykSecurityScan function in shared Library. (Snyks labeling, what they call tags, does not allow special characters that is the purpose of regex to replace the with the only allowed character '_' , this is just for filtering on server)

Sample run: https://ci01.dev.r3.com/job/Corda-Shell/view/change-requests/job/PR-40/