### PR TITLE
INFRA-1909: add snyk scanning to corda-shell ent project 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
         CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
         CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
         CORDA_USE_CACHE = "corda-remotes"
-        SNYK_API_KEY = "c4-ent-snyk-shell"
+        SNYK_TOKEN = "c4-ent-snyk-shell"
     }
 
     stages {
@@ -132,7 +132,7 @@ pipeline {
                     // Invoke Snyk for each Gradle sub project we wish to scan
                     def modulesToScan = ['standalone-shell', 'shell']
                     modulesToScan.each { module ->
-                        snykSecurityScan(env.SNYK_API_KEY, "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'")
+                        snykSecurityScan(env.SNYK_TOKEN, "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'")
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,7 +132,7 @@ pipeline {
                     // Invoke Snyk for each Gradle sub project we wish to scan
                     def modulesToScan = ['standalone-shell', 'shell']
                     modulesToScan.each { module ->
-                        snykSecurityScan(env.SNYK_TOKEN, "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'")
+                        snykSecurityScan(env.SNYK_API_KEY, "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'")
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
         CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
         CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
         CORDA_USE_CACHE = "corda-remotes"
-        SNYK_TOKEN  = credentials('c4-ent-snyk-shell')
+        SNYK_API_KEY = "c4-ent-snyk-shell"
     }
 
     stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,6 +78,7 @@ pipeline {
         CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
         CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
         CORDA_USE_CACHE = "corda-remotes"
+        SNYK_TOKEN  = credentials('c4-ent-snyk-shell')
     }
 
     stages {
@@ -120,6 +121,21 @@ pipeline {
                         )
                 }
              }
+        }
+
+        stage('Snyk Security') {
+            // when {
+            //     expression { isRelease || isReleaseBranch }
+            // }
+            steps {
+                script {
+                    // Invoke Snyk for each Gradle sub project we wish to scan
+                    def modulesToScan = ['standalone-shell', 'shell']
+                    modulesToScan.each { module ->
+                        snykSecurityScan(env.SNYK_TOKEN, "--sub-project=$module --configuration-matching='^runtimeClasspath\$' --prune-repeated-subdependencies --debug --target-reference='${env.BRANCH_NAME}' --project-tags=Branch='${env.BRANCH_NAME.replaceAll("[^0-9|a-z|A-Z]+","_")}'")
+                    }
+                }
+            }
         }
 
         stage('Build') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,9 +124,9 @@ pipeline {
         }
 
         stage('Snyk Security') {
-            // when {
-            //     expression { isRelease || isReleaseBranch }
-            // }
+            when {
+                expression { isRelease || isReleaseBranch }
+            }
             steps {
                 script {
                     // Invoke Snyk for each Gradle sub project we wish to scan


### PR DESCRIPTION
Add standard Snyk scanning logic to the project CI for release and tag builds

Loop through modules to scan calling `snykSecurityScan` function in shared Library.  (Snyks labeling, what they call tags, does not allow special characters that is the purpose of regex to replace the with the only allowed character '_' , this is just for filtering on server)

Sample run: https://ci01.dev.r3.com/job/Corda-Shell/view/change-requests/job/PR-41/