### PR TITLE
ENT-9105 Two Phase Finality node shell commands

### DIFF
--- a/shell/src/integration-test/kotlin/net/corda/tools/shell/FlowRPCCommandTest.kt
+++ b/shell/src/integration-test/kotlin/net/corda/tools/shell/FlowRPCCommandTest.kt
@@ -14,6 +14,7 @@ import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.millis
 import net.corda.failingflows.workflows.HospitalizerFlow
 import net.corda.node.services.Permissions
+import net.corda.node.services.api.ServiceHubInternal
 import net.corda.testing.contracts.DummyContract
 import net.corda.testing.core.ALICE_NAME
 import net.corda.testing.core.BOB_NAME
@@ -117,7 +118,7 @@ class FlowRPCCommandTest : CommandTestBase() {
     @StartableByRPC
     class PauseFlow : FlowLogic<Unit>() {
         companion object {
-            var beforePause: Semaphore? = null;
+            var beforePause: Semaphore? = null
         }
 
         @Suspendable
@@ -147,7 +148,7 @@ class FlowRPCCommandTest : CommandTestBase() {
         override fun call(): SignedTransaction {
             val txBuilder = DummyContract.move(stateAndRef, newOwner)
             val signedTransaction = serviceHub.signInitialTransaction(txBuilder, ourIdentity.owningKey)
-            serviceHub.recordUnnotarisedTransaction(signedTransaction, FlowTransactionMetadata(
+            (serviceHub as ServiceHubInternal).recordUnnotarisedTransaction(signedTransaction, FlowTransactionMetadata(
                 initiator = ourIdentity.name,
                 peers = setOf(newOwner.name)
             ))

--- a/shell/src/integration-test/kotlin/net/corda/tools/shell/FlowRPCCommandTest.kt
+++ b/shell/src/integration-test/kotlin/net/corda/tools/shell/FlowRPCCommandTest.kt
@@ -1,21 +1,32 @@
 package net.corda.tools.shell
 
 import co.paralleluniverse.fibers.Suspendable
-import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.StartableByRPC
+import net.corda.core.CordaRuntimeException
+import net.corda.core.contracts.StateAndRef
+import net.corda.core.crypto.SecureHash
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
 import net.corda.core.messaging.startFlow
 import net.corda.core.messaging.startTrackedFlow
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
 import net.corda.core.utilities.getOrThrow
 import net.corda.core.utilities.millis
 import net.corda.failingflows.workflows.HospitalizerFlow
 import net.corda.node.services.Permissions
+import net.corda.testing.contracts.DummyContract
+import net.corda.testing.contracts.DummyState
 import net.corda.testing.core.ALICE_NAME
+import net.corda.testing.core.BOB_NAME
 import net.corda.testing.driver.DriverParameters
+import net.corda.testing.driver.NodeParameters
 import net.corda.testing.driver.driver
+import net.corda.testing.node.TestCordapp
 import net.corda.testing.node.User
 import net.corda.testing.node.internal.cordappWithPackages
 import org.junit.Test
 import java.time.Duration
+import java.util.*
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeoutException
 import kotlin.test.assertEquals
@@ -24,7 +35,8 @@ import kotlin.test.assertFailsWith
 @SuppressWarnings("TooGenericExceptionCaught")
 class FlowRPCCommandTest : CommandTestBase() {
 
-    val customCordapp = cordappWithPackages("net.corda.failingflows.workflows")
+    val customCordapp = cordappWithPackages("net.corda.failingflows.workflows",
+        "net.corda.tools.shell")
 
     @Test(timeout = 300_000)
     fun `Hospitalised flows can be retried via the shell`() {
@@ -43,8 +55,16 @@ class FlowRPCCommandTest : CommandTestBase() {
             assertFailsWith<TimeoutException> { handle.returnValue.getOrThrow(timeout = Duration.ofSeconds(30)) }
             assertEquals(1, timesThrown)
             val session = connectToShell(user, node)
-            testCommand(session, command = "flowStatus queryById ${id.uuid.toString().toLowerCase()}", expected = "HOSPITALIZED")
-            testCommand(session, command = "flow retry ${id.uuid.toString().toLowerCase()}", expected = "Retried flow $id")
+            testCommand(
+                session,
+                command = "flowStatus queryById ${id.uuid.toString().toLowerCase()}",
+                expected = "HOSPITALIZED"
+            )
+            testCommand(
+                session,
+                command = "flow retry ${id.uuid.toString().toLowerCase()}",
+                expected = "Retried flow $id"
+            )
             assertFailsWith<TimeoutException> { handle.returnValue.getOrThrow(timeout = Duration.ofSeconds(10)) }
             assertEquals(2, timesThrown)
             session.disconnect()
@@ -55,17 +75,67 @@ class FlowRPCCommandTest : CommandTestBase() {
     fun `A flow can be paused and resumed via the shell`() {
         val user = User("username", "password", setOf(Permissions.all()))
         driver(DriverParameters(notarySpecs = emptyList(), cordappsForAllNodes = listOf(customCordapp))) {
-            val node = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user), startInSameProcess = true).getOrThrow()
+            val node =
+                startNode(providedName = ALICE_NAME, rpcUsers = listOf(user), startInSameProcess = true).getOrThrow()
             PauseFlow.beforePause = Semaphore(0)
             val handle = node.rpc.startFlow(::PauseFlow)
             val id = handle.id
             val session = connectToShell(user, node)
-            testCommand(session, command = "flow pause ${id.uuid.toString().toLowerCase()}", expected = "Paused flow $id")
+            testCommand(
+                session,
+                command = "flow pause ${id.uuid.toString().toLowerCase()}",
+                expected = "Paused flow $id"
+            )
             PauseFlow.beforePause!!.release()
             Thread.sleep(5000) //Wait for the Statemachine to go through a pause transition.
-            testCommand(session, command = "flowStatus queryById ${id.uuid.toString().toLowerCase()}", expected = "PAUSED")
-            testCommand(session, command = "flow retry ${id.uuid.toString().toLowerCase()}", expected = "Retried flow $id")
+            testCommand(
+                session,
+                command = "flowStatus queryById ${id.uuid.toString().toLowerCase()}",
+                expected = "PAUSED"
+            )
+            testCommand(
+                session,
+                command = "flow retry ${id.uuid.toString().toLowerCase()}",
+                expected = "Retried flow $id"
+            )
             handle.returnValue.getOrThrow()
+        }
+    }
+
+    @Test(timeout = 300_000)
+    fun `A finality flow can be recovered via the shell`() {
+        val user = User("username", "password", setOf(Permissions.all()))
+        driver(DriverParameters(cordappsForAllNodes = listOf(customCordapp))) {
+            val alice =
+                startNode(providedName = ALICE_NAME, rpcUsers = listOf(user),
+                    defaultParameters = NodeParameters(additionalCordapps =
+                        setOf(TestCordapp.findCordapp("net.corda.testing.contracts"))),
+                    startInSameProcess = true).getOrThrow()
+            val bob =
+                startNode(providedName = BOB_NAME, rpcUsers = listOf(user), startInSameProcess = true).getOrThrow()
+            PauseFlow.beforePause = Semaphore(0)
+            val handle = alice.rpc.startFlow(::CreateTransactionFlow, bob.nodeInfo.legalIdentities.first())
+            val id = handle.id
+            try { handle.returnValue.getOrThrow() }
+            catch (e: FinalityFlowException) {
+                println(e.message)
+                val session = connectToShell(user, alice)
+//            testCommand(
+//                session,
+//                command = "flowStatus queryById ${id.uuid.toString().toLowerCase()}",
+//                expected = "PAUSED"
+//            )
+//            testCommand(
+//                session,
+//                command = "flow recover ${id.uuid.toString().toLowerCase()}",
+//                expected = "Recovered finality flow $id"
+//            )
+                testCommand(
+                    session,
+                    command = "flow recoverByTxnId ${e.txnId}",
+                    expected = "Recovered finality flow $id"
+                )
+            }
         }
     }
 
@@ -81,4 +151,43 @@ class FlowRPCCommandTest : CommandTestBase() {
             sleep(10.millis)
         }
     }
+
+    @InitiatingFlow
+    @StartableByRPC
+    class CreateTransactionFlow(private val peer: Party) : FlowLogic<StateAndRef<DummyState>>() {
+        @Suspendable
+        override fun call(): StateAndRef<DummyState> {
+            val tx = TransactionBuilder(serviceHub.networkMapCache.notaryIdentities.first()).apply {
+                addOutputState(DummyState(participants = listOf(ourIdentity)))
+                addCommand(DummyContract.Commands.Create(), listOf(ourIdentity.owningKey, peer.owningKey))
+            }
+            val stx = serviceHub.signInitialTransaction(tx)
+            val session = initiateFlow(peer)
+            try {
+                val ftx = subFlow(CollectSignaturesFlow(stx, listOf(session)))
+                subFlow(FinalityFlow(ftx, session))
+                return ftx.coreTransaction.outRef(0)
+            }
+            catch (e: UnexpectedFlowEndException) {
+                throw FinalityFlowException(stx.id, runId.uuid)
+            }
+        }
+    }
+
+    @InitiatedBy(CreateTransactionFlow::class)
+    class CreateTransactionResponderFlow(private val session: FlowSession) : FlowLogic<Unit>() {
+        @Suspendable
+        override fun call() {
+            val stx = subFlow(object : SignTransactionFlow(session) {
+                override fun checkTransaction(stx: SignedTransaction) {
+
+                }
+            })
+//            throw FinalityFlowException(stx.id, runId.uuid)
+            subFlow(ReceiveFinalityFlow(session, stx.id))
+        }
+    }
+
+    class FinalityFlowException(val txnId: SecureHash, val flowId: UUID)
+        : FlowException("Finality flow $flowId failed for transaction id: $txnId")
 }

--- a/shell/src/integration-test/kotlin/net/corda/tools/shell/FlowRPCCommandTest.kt
+++ b/shell/src/integration-test/kotlin/net/corda/tools/shell/FlowRPCCommandTest.kt
@@ -120,12 +120,12 @@ class FlowRPCCommandTest : CommandTestBase() {
                 testCommand(
                     session,
                     command = "flowStatus queryFinalityById ${e.flowId}",
-                    expected = ""
+                    expected = "status: \"MISSING_NOTARY_SIG\""
                 )
                 testCommand(
                     session,
                     command = "flowStatus queryFinalityByTxnId ${e.txnId}",
-                    expected = ""
+                    expected = "status: \"MISSING_NOTARY_SIG\""
                 )
                 testCommand(
                     session,

--- a/shell/src/integration-test/kotlin/net/corda/tools/shell/FlowRPCCommandTest.kt
+++ b/shell/src/integration-test/kotlin/net/corda/tools/shell/FlowRPCCommandTest.kt
@@ -34,8 +34,7 @@ import kotlin.test.fail
 @SuppressWarnings("TooGenericExceptionCaught")
 class FlowRPCCommandTest : CommandTestBase() {
 
-    val customCordapp = cordappWithPackages("net.corda.failingflows.workflows",
-        "net.corda.tools.shell")
+    val customCordapp = cordappWithPackages("net.corda.failingflows.workflows", "net.corda.tools.shell")
 
     @Test(timeout = 300_000)
     fun `Hospitalised flows can be retried via the shell`() {
@@ -54,16 +53,8 @@ class FlowRPCCommandTest : CommandTestBase() {
             assertFailsWith<TimeoutException> { handle.returnValue.getOrThrow(timeout = Duration.ofSeconds(30)) }
             assertEquals(1, timesThrown)
             val session = connectToShell(user, node)
-            testCommand(
-                session,
-                command = "flowStatus queryById ${id.uuid.toString().toLowerCase()}",
-                expected = "HOSPITALIZED"
-            )
-            testCommand(
-                session,
-                command = "flow retry ${id.uuid.toString().toLowerCase()}",
-                expected = "Retried flow $id"
-            )
+            testCommand(session, command = "flowStatus queryById ${id.uuid.toString().toLowerCase()}", expected = "HOSPITALIZED")
+            testCommand(session, command = "flow retry ${id.uuid.toString().toLowerCase()}", expected = "Retried flow $id")
             assertFailsWith<TimeoutException> { handle.returnValue.getOrThrow(timeout = Duration.ofSeconds(10)) }
             assertEquals(2, timesThrown)
             session.disconnect()
@@ -74,29 +65,16 @@ class FlowRPCCommandTest : CommandTestBase() {
     fun `A flow can be paused and resumed via the shell`() {
         val user = User("username", "password", setOf(Permissions.all()))
         driver(DriverParameters(notarySpecs = emptyList(), cordappsForAllNodes = listOf(customCordapp))) {
-            val node =
-                startNode(providedName = ALICE_NAME, rpcUsers = listOf(user), startInSameProcess = true).getOrThrow()
+            val node = startNode(providedName = ALICE_NAME, rpcUsers = listOf(user), startInSameProcess = true).getOrThrow()
             PauseFlow.beforePause = Semaphore(0)
             val handle = node.rpc.startFlow(::PauseFlow)
             val id = handle.id
             val session = connectToShell(user, node)
-            testCommand(
-                session,
-                command = "flow pause ${id.uuid.toString().toLowerCase()}",
-                expected = "Paused flow $id"
-            )
+            testCommand(session, command = "flow pause ${id.uuid.toString().toLowerCase()}", expected = "Paused flow $id")
             PauseFlow.beforePause!!.release()
             Thread.sleep(5000) //Wait for the Statemachine to go through a pause transition.
-            testCommand(
-                session,
-                command = "flowStatus queryById ${id.uuid.toString().toLowerCase()}",
-                expected = "PAUSED"
-            )
-            testCommand(
-                session,
-                command = "flow retry ${id.uuid.toString().toLowerCase()}",
-                expected = "Retried flow $id"
-            )
+            testCommand(session, command = "flowStatus queryById ${id.uuid.toString().toLowerCase()}", expected = "PAUSED")
+            testCommand(session, command = "flow retry ${id.uuid.toString().toLowerCase()}", expected = "Retried flow $id")
             handle.returnValue.getOrThrow()
         }
     }

--- a/shell/src/integration-test/kotlin/net/corda/tools/shell/FlowRPCCommandTest.kt
+++ b/shell/src/integration-test/kotlin/net/corda/tools/shell/FlowRPCCommandTest.kt
@@ -99,12 +99,12 @@ class FlowRPCCommandTest : CommandTestBase() {
                 testCommand(
                     session,
                     command = "flowStatus queryFinalityById ${e.flowId}",
-                    expected = "status: \"MISSING_NOTARY_SIG\""
+                    expected = "status: \"IN_FLIGHT\""
                 )
                 testCommand(
                     session,
                     command = "flowStatus queryFinalityByTxnId ${e.txnId}",
-                    expected = "status: \"MISSING_NOTARY_SIG\""
+                    expected = "status: \"IN_FLIGHT\""
                 )
                 testCommand(
                     session,

--- a/shell/src/main/java/net/corda/tools/shell/FlowRPCShellCommand.java
+++ b/shell/src/main/java/net/corda/tools/shell/FlowRPCShellCommand.java
@@ -1,9 +1,12 @@
 package net.corda.tools.shell;
 
 import net.corda.client.rpc.proxy.FlowRPCOps;
+import net.corda.core.crypto.SecureHash;
 import net.corda.core.flows.StateMachineRunId;
 import org.crsh.command.RuntimeContext;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
 
 public class FlowRPCShellCommand extends InteractiveShellCommand<FlowRPCOps> {
 
@@ -40,4 +43,13 @@ public class FlowRPCShellCommand extends InteractiveShellCommand<FlowRPCOps> {
     Boolean retryAllPausedHospitalized() {
         return ops().retryAllPausedHospitalizedFlows();
     }
+
+    Boolean recoverFinalityFlow(StateMachineRunId id, Boolean forceRecover) { return ops().recoverFinalityFlow(id, forceRecover); }
+    Boolean recoverFinalityFlow(StateMachineRunId id) { return ops().recoverFinalityFlow(id, false); }
+
+    Boolean recoverFinalityFlowByTxnId(SecureHash txnId, Boolean forceRecover) { return ops().recoverFinalityFlowByTxnId(txnId, forceRecover); }
+    Boolean recoverFinalityFlowByTxnId(SecureHash txnId) { return ops().recoverFinalityFlowByTxnId(txnId, false); }
+
+    Map<StateMachineRunId, Boolean> recoverAllFinalityFlows(Boolean forceRecover) { return ops().recoverAllFinalityFlows(forceRecover); }
+    Map<StateMachineRunId, Boolean> recoverAllFinalityFlows() { return ops().recoverAllFinalityFlows(false); }
 }

--- a/shell/src/main/java/net/corda/tools/shell/FlowShellCommand.java
+++ b/shell/src/main/java/net/corda/tools/shell/FlowShellCommand.java
@@ -189,12 +189,12 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
 
     @Command
     @Usage("Recover a finality flow by flow uuid.")
-    public void recover(
+    public void recoverFinality(
             @Usage("The UUID for the flow that we wish to recover") @Argument String id,
             @Usage("Flag to force recovery of flows that are in a HOSPITALIZED or PAUSED state.")
             @Option(names = { "f", "force-recover" }) Boolean forceRecover
     ) {
-        logger.info("Executing command \"flow recover {}\".", id);
+        logger.info("Executing command \"flow recoverFinality {}\".", id);
         StateMachineRunId parsedId = parseStateMachineRunId(id, out, objectMapper(null));
 
         Boolean recoveryResult;
@@ -212,12 +212,12 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
 
     @Command
     @Usage("Recover a finality flow by transaction id.")
-    public void recoverByTxnId(
+    public void recoverFinalityByTxnId(
             @Usage("The SecureHash of the transaction that we wish to recover") @Argument String id,
             @Usage("Flag to force recovery of flows that are in a HOSPITALIZED or PAUSED state.")
             @Option(names = { "f", "force-recover" }) Boolean forceRecover
     ) {
-        logger.info("Executing command \"flow recoverByTxnId {}\".", id);
+        logger.info("Executing command \"flow recoverFinalityByTxnId {}\".", id);
         SecureHash txIdHashParsed;
         try {
             txIdHashParsed = SecureHash.create(id);
@@ -239,11 +239,11 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
 
     @Command
     @Usage("Recover all finality flows that have failed on this node.")
-    public void recoverAll(
+    public void recoverAllFinality(
         @Usage("Flag to force recovery of flows that are in a HOSPITALIZED or PAUSED state.")
         @Option(names = { "f", "force-recover" }) Boolean forceRecover
     ) {
-        logger.info("Executing command \"flow recoverAll {}\".");
+        logger.info("Executing command \"flow recoverAllFinality {}\".");
 
         Map<StateMachineRunId, Boolean> recoveredFlows;
         if (forceRecover != null)
@@ -267,13 +267,13 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
             "\t\tinitiatedBy: String [X509 name, like O=PartyA,L=London,C=GB] - the name of the party that initiated the flow\n" +
             "\t\tcounterParties: String [X509 name, like O=PartyA,L=London,C=GB] - the name of any counter party peers receiving the flow, , can be specified as an array like [\"O=PartyA,L=London,C=GB\", \"O=PartyB,L=London,C=GB\"]\n"
     )
-    public void recoverMatching(
+    public void recoverFinalityMatching(
         InvocationContext<Map> context,
         @Argument(unquote = true) List<String> input,
         @Usage("Flag to force recovery of flows that are in a HOSPITALIZED or PAUSED state.")
         @Option(names = { "f", "force-recover" }) Boolean forceRecover
     ) {
-        logger.info("Executing command \"flow recoverMatching {}\".");
+        logger.info("Executing command \"flow recoverFinalityMatching {}\".");
 
         Map<StateMachineRunId, Boolean> recoveredFlows;
         if (forceRecover != null)

--- a/shell/src/main/java/net/corda/tools/shell/FlowShellCommand.java
+++ b/shell/src/main/java/net/corda/tools/shell/FlowShellCommand.java
@@ -4,15 +4,13 @@ package net.corda.tools.shell;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
+import net.corda.client.rpc.proxy.FlowRPCOps;
+import net.corda.core.crypto.SecureHash;
 import net.corda.core.flows.StateMachineRunId;
 import net.corda.core.messaging.CordaRPCOps;
 import net.corda.tools.shell.utlities.ANSIProgressRenderer;
 import net.corda.tools.shell.utlities.CRaSHANSIProgressRenderer;
-import org.crsh.cli.Argument;
-import org.crsh.cli.Command;
-import org.crsh.cli.Man;
-import org.crsh.cli.Named;
-import org.crsh.cli.Usage;
+import org.crsh.cli.*;
 import org.crsh.command.InvocationContext;
 import org.crsh.text.Color;
 import org.crsh.text.Decoration;
@@ -21,15 +19,18 @@ import org.crsh.text.ui.TableElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static net.corda.tools.shell.InteractiveShell.killFlowById;
 import static net.corda.tools.shell.InteractiveShell.parseStateMachineRunId;
 import static net.corda.tools.shell.InteractiveShell.runFlowByNameFragment;
 import static net.corda.tools.shell.InteractiveShell.runStateMachinesView;
+import static net.corda.tools.shell.utlities.FlowRecoveryParserKt.queryRecoveryFlows;
 
 @Man(
-    "Allows you to start and kill flows, list the ones available and to watch flows currently running on the node.\n\n" +
+    "Allows you to start, kill, pause, retry and recover flows, list the ones available and to watch flows currently running on the node.\n\n" +
         "Starting flow is the primary way in which you command the node to change the ledger.\n\n" +
         "This command is generic, so the right way to use it depends on the flow you wish to start. You can use the 'flow start'\n" +
         "command with either a full class name, or a substring of the class name that's unambiguous. The parameters to the \n" +
@@ -52,13 +53,13 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
 
     @Command
     @Usage("Start a (work)flow on the node. This is how you can change the ledger.\n\n" +
-        "\t\t    Starting flow is the primary way in which you command the node to change the ledger.\n" +
-        "\t\t    This command is generic, so the right way to use it depends on the flow you wish to start. You can use the 'flow start'\n" +
-        "\t\t    command with either a full class name, or a substring of the class name that's unambiguous. The parameters to the\n" +
-        "\t\t    flow constructors (the right one is picked automatically) are then specified using the same syntax as for the run command.\n")
+            "\t\t    Starting flow is the primary way in which you command the node to change the ledger.\n" +
+            "\t\t    This command is generic, so the right way to use it depends on the flow you wish to start. You can use the 'flow start'\n" +
+            "\t\t    command with either a full class name, or a substring of the class name that's unambiguous. The parameters to the\n" +
+            "\t\t    flow constructors (the right one is picked automatically) are then specified using the same syntax as for the run command.\n")
     public void start(
-        @Usage("The class name of the flow to run, or an unambiguous substring") @Argument String name,
-        @Usage("The data to pass as input") @Argument(unquote = false) List<String> input
+            @Usage("The class name of the flow to run, or an unambiguous substring") @Argument String name,
+            @Usage("The data to pass as input") @Argument(unquote = false) List<String> input
     ) {
         logger.info("Executing command \"flow start {} {}\",", name, (input != null) ? String.join(" ", input) : "<no arguments>");
         startFlow(name, input, out, ops(), ansiProgressRenderer(), objectMapper(null));
@@ -74,12 +75,12 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
     }
 
     static void startFlow(
-        @Usage("The class name of the flow to run, or an unambiguous substring") @Argument String name,
-        @Usage("The data to pass as input") @Argument(unquote = false) List<String> input,
-        RenderPrintWriter out,
-        CordaRPCOps rpcOps,
-        ANSIProgressRenderer ansiProgressRenderer,
-        ObjectMapper om
+            @Usage("The class name of the flow to run, or an unambiguous substring") @Argument String name,
+            @Usage("The data to pass as input") @Argument(unquote = false) List<String> input,
+            RenderPrintWriter out,
+            CordaRPCOps rpcOps,
+            ANSIProgressRenderer ansiProgressRenderer,
+            ObjectMapper om
     ) {
         if (name == null) {
             out.println("You must pass a name for the flow. Example: \"start Yo target: Some other company\"", Decoration.bold, Color.red);
@@ -87,12 +88,12 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
         }
         String inp = input == null ? "" : String.join(" ", input).trim();
         runFlowByNameFragment(
-            name,
-            inp,
-            out,
-            rpcOps,
-            ansiProgressRenderer != null ? ansiProgressRenderer : new CRaSHANSIProgressRenderer(out),
-            om
+                name,
+                inp,
+                out,
+                rpcOps,
+                ansiProgressRenderer != null ? ansiProgressRenderer : new CRaSHANSIProgressRenderer(out),
+                om
         );
     }
 
@@ -108,7 +109,7 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
     @Command
     @Usage("Kill a flow that is running on this node.")
     public void kill(
-        @Usage("The UUID for the flow that we wish to kill") @Argument String id
+            @Usage("The UUID for the flow that we wish to kill") @Argument String id
     ) {
         logger.info("Executing command \"flow kill {}\".", id);
         killFlowById(id, out, ops(), objectMapper(null));
@@ -117,7 +118,7 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
     @Command
     @Usage("Pause a flow that is running on this node.")
     public void pause(
-        @Usage("The UUID for the flow that we wish to pause") @Argument String id
+            @Usage("The UUID for the flow that we wish to pause") @Argument String id
     ) {
         logger.info("Executing command \"flow pause {}\".", id);
         StateMachineRunId parsedId = parseStateMachineRunId(id, out, objectMapper(null));
@@ -153,7 +154,7 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
     @Command
     @Usage("Retry a flow that is running on this node.")
     public void retry(
-        @Usage("The UUID for the flow that we wish to retry") @Argument String id
+            @Usage("The UUID for the flow that we wish to retry") @Argument String id
     ) {
         logger.info("Executing command \"flow retry {}\".", id);
         StateMachineRunId parsedId = parseStateMachineRunId(id, out, objectMapper(null));
@@ -183,6 +184,108 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
             out.println("Retrying all paused hospitalized flows succeeded.", Decoration.bold, Color.yellow);
         } else {
             out.println("One or more paused hospitalized flows failed to retry.", Decoration.bold, Color.red);
+        }
+    }
+
+    @Command
+    @Usage("Recover a finality flow by flow uuid.")
+    public void recover(
+            @Usage("The UUID for the flow that we wish to recover") @Argument String id,
+            @Usage("Flag to force recovery of flows that are in a HOSPITALIZED or PAUSED state.")
+            @Option(names = { "f", "force-recover" }) Boolean forceRecover
+    ) {
+        logger.info("Executing command \"flow recover {}\".", id);
+        StateMachineRunId parsedId = parseStateMachineRunId(id, out, objectMapper(null));
+
+        Boolean recoveryResult;
+        if (forceRecover != null)
+            recoveryResult = getFlowRPCShellCommand().recoverFinalityFlow(parsedId, forceRecover);
+        else
+            recoveryResult = getFlowRPCShellCommand().recoverFinalityFlow(parsedId);
+
+        if (recoveryResult) {
+            out.println("Recovered finality flow " + parsedId, Decoration.bold, Color.yellow);
+        } else {
+            out.println("Failed to recover finality flow " + parsedId, Decoration.bold, Color.red);
+        }
+    }
+
+    @Command
+    @Usage("Recover a finality flow by transaction id.")
+    public void recoverByTxnId(
+            @Usage("The SecureHash of the transaction that we wish to recover") @Argument String id,
+            @Usage("Flag to force recovery of flows that are in a HOSPITALIZED or PAUSED state.")
+            @Option(names = { "f", "force-recover" }) Boolean forceRecover
+    ) {
+        logger.info("Executing command \"flow recoverByTxnId {}\".", id);
+        SecureHash txIdHashParsed;
+        try {
+            txIdHashParsed = SecureHash.create(id);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("The provided string is neither a valid SHA-256 hash value or a supported hash algorithm");
+        }
+        Boolean recoveryResult;
+        if (forceRecover != null)
+            recoveryResult = getFlowRPCShellCommand().recoverFinalityFlowByTxnId(txIdHashParsed, forceRecover);
+        else
+            recoveryResult = getFlowRPCShellCommand().recoverFinalityFlowByTxnId(txIdHashParsed);
+
+        if (recoveryResult) {
+            out.println("Recovered finality flow " + txIdHashParsed, Decoration.bold, Color.yellow);
+        } else {
+            out.println("Failed to recover finality flow " + txIdHashParsed, Decoration.bold, Color.red);
+        }
+    }
+
+    @Command
+    @Usage("Recover all finality flows that have failed on this node.")
+    public void recoverAll(
+        @Usage("Flag to force recovery of flows that are in a HOSPITALIZED or PAUSED state.")
+        @Option(names = { "f", "force-recover" }) Boolean forceRecover
+    ) {
+        logger.info("Executing command \"flow recoverAll {}\".");
+
+        Map<StateMachineRunId, Boolean> recoveredFlows;
+        if (forceRecover != null)
+            recoveredFlows = getFlowRPCShellCommand().recoverAllFinalityFlows(forceRecover);
+        else
+            recoveredFlows = getFlowRPCShellCommand().recoverAllFinalityFlows();
+
+        if (!recoveredFlows.isEmpty()) {
+            out.println("Recovered finality flow(s) ", Decoration.bold, Color.yellow);
+            out.println("Results: " + Arrays.toString(recoveredFlows.entrySet().toArray()), Decoration.bold, Color.yellow );
+        } else {
+            out.println("Failed to recover finality flow(s) ", Decoration.bold, Color.red);
+        }
+    }
+
+    @Command
+    @Usage("Recover all finality flows that have failed on this node and match the search query criteria.\n" +
+            "\tAvailable search criteria arguments are: \n" +
+            "\t\tflowStartFromTime: String [ISO8601 DateTime] - the start of a time window where the flow was started - if not present taken to be 0 unix timestamp\n" +
+            "\t\tflowStartUntilTime: String [ISO8601 DateTime] - the end of a time window where the flow was started - if not present taken to be the current utc unix timestamp\n" +
+            "\t\tinitiatedBy: String [X509 name, like O=PartyA,L=London,C=GB] - the name of the party that initiated the flow\n" +
+            "\t\tcounterParties: String [X509 name, like O=PartyA,L=London,C=GB] - the name of any counter party peers receiving the flow, , can be specified as an array like [\"O=PartyA,L=London,C=GB\", \"O=PartyB,L=London,C=GB\"]\n"
+    )
+    public void recoverMatching(
+        InvocationContext<Map> context,
+        @Argument(unquote = true) List<String> input,
+        @Usage("Flag to force recovery of flows that are in a HOSPITALIZED or PAUSED state.")
+        @Option(names = { "f", "force-recover" }) Boolean forceRecover
+    ) {
+        logger.info("Executing command \"flow recoverMatching {}\".");
+
+        Map<StateMachineRunId, Boolean> recoveredFlows;
+        if (forceRecover != null)
+            recoveredFlows = queryRecoveryFlows(context.getWriter(), input, ops(FlowRPCOps.class), ops(CordaRPCOps.class), forceRecover);
+        else
+            recoveredFlows = queryRecoveryFlows(context.getWriter(), input, ops(FlowRPCOps.class), ops(CordaRPCOps.class));
+
+        if (!recoveredFlows.isEmpty()) {
+            out.println("Recovered finality flow(s) ", Decoration.bold, Color.yellow);
+            out.println("Results: " + Arrays.toString(recoveredFlows.entrySet().toArray()), Decoration.bold, Color.yellow );
+        } else {
+            out.println("Failed to recover finality flow(s) ", Decoration.bold, Color.red);
         }
     }
 }

--- a/shell/src/main/java/net/corda/tools/shell/FlowShellCommand.java
+++ b/shell/src/main/java/net/corda/tools/shell/FlowShellCommand.java
@@ -53,13 +53,13 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
 
     @Command
     @Usage("Start a (work)flow on the node. This is how you can change the ledger.\n\n" +
-            "\t\t    Starting flow is the primary way in which you command the node to change the ledger.\n" +
-            "\t\t    This command is generic, so the right way to use it depends on the flow you wish to start. You can use the 'flow start'\n" +
-            "\t\t    command with either a full class name, or a substring of the class name that's unambiguous. The parameters to the\n" +
-            "\t\t    flow constructors (the right one is picked automatically) are then specified using the same syntax as for the run command.\n")
+        "\t\t    Starting flow is the primary way in which you command the node to change the ledger.\n" +
+        "\t\t    This command is generic, so the right way to use it depends on the flow you wish to start. You can use the 'flow start'\n" +
+        "\t\t    command with either a full class name, or a substring of the class name that's unambiguous. The parameters to the\n" +
+        "\t\t    flow constructors (the right one is picked automatically) are then specified using the same syntax as for the run command.\n")
     public void start(
-            @Usage("The class name of the flow to run, or an unambiguous substring") @Argument String name,
-            @Usage("The data to pass as input") @Argument(unquote = false) List<String> input
+        @Usage("The class name of the flow to run, or an unambiguous substring") @Argument String name,
+        @Usage("The data to pass as input") @Argument(unquote = false) List<String> input
     ) {
         logger.info("Executing command \"flow start {} {}\",", name, (input != null) ? String.join(" ", input) : "<no arguments>");
         startFlow(name, input, out, ops(), ansiProgressRenderer(), objectMapper(null));
@@ -75,12 +75,12 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
     }
 
     static void startFlow(
-            @Usage("The class name of the flow to run, or an unambiguous substring") @Argument String name,
-            @Usage("The data to pass as input") @Argument(unquote = false) List<String> input,
-            RenderPrintWriter out,
-            CordaRPCOps rpcOps,
-            ANSIProgressRenderer ansiProgressRenderer,
-            ObjectMapper om
+        @Usage("The class name of the flow to run, or an unambiguous substring") @Argument String name,
+        @Usage("The data to pass as input") @Argument(unquote = false) List<String> input,
+        RenderPrintWriter out,
+        CordaRPCOps rpcOps,
+        ANSIProgressRenderer ansiProgressRenderer,
+        ObjectMapper om
     ) {
         if (name == null) {
             out.println("You must pass a name for the flow. Example: \"start Yo target: Some other company\"", Decoration.bold, Color.red);
@@ -88,12 +88,12 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
         }
         String inp = input == null ? "" : String.join(" ", input).trim();
         runFlowByNameFragment(
-                name,
-                inp,
-                out,
-                rpcOps,
-                ansiProgressRenderer != null ? ansiProgressRenderer : new CRaSHANSIProgressRenderer(out),
-                om
+            name,
+            inp,
+            out,
+            rpcOps,
+            ansiProgressRenderer != null ? ansiProgressRenderer : new CRaSHANSIProgressRenderer(out),
+            om
         );
     }
 
@@ -109,7 +109,7 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
     @Command
     @Usage("Kill a flow that is running on this node.")
     public void kill(
-            @Usage("The UUID for the flow that we wish to kill") @Argument String id
+        @Usage("The UUID for the flow that we wish to kill") @Argument String id
     ) {
         logger.info("Executing command \"flow kill {}\".", id);
         killFlowById(id, out, ops(), objectMapper(null));
@@ -118,7 +118,7 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
     @Command
     @Usage("Pause a flow that is running on this node.")
     public void pause(
-            @Usage("The UUID for the flow that we wish to pause") @Argument String id
+        @Usage("The UUID for the flow that we wish to pause") @Argument String id
     ) {
         logger.info("Executing command \"flow pause {}\".", id);
         StateMachineRunId parsedId = parseStateMachineRunId(id, out, objectMapper(null));
@@ -154,7 +154,7 @@ public class FlowShellCommand extends CordaRpcOpsShellCommand {
     @Command
     @Usage("Retry a flow that is running on this node.")
     public void retry(
-            @Usage("The UUID for the flow that we wish to retry") @Argument String id
+        @Usage("The UUID for the flow that we wish to retry") @Argument String id
     ) {
         logger.info("Executing command \"flow retry {}\".", id);
         StateMachineRunId parsedId = parseStateMachineRunId(id, out, objectMapper(null));

--- a/shell/src/main/kotlin/net/corda/tools/shell/FlowStatusQueryCommand.kt
+++ b/shell/src/main/kotlin/net/corda/tools/shell/FlowStatusQueryCommand.kt
@@ -163,7 +163,7 @@ internal class FlowStatusQueryCommand : MultiRpcInteractiveShellCommand() {
         @Suppress("TooGenericExceptionCaught")
         fun queryFinalityByTxnId(writer: PrintWriter, input: List<String>?, ops: NodeFlowStatusRpcOps) {
             val results = input?.mapNotNull { id ->
-                ops.getFlowTransactionByTxnId(id).apply { println(this) }
+                ops.getFlowTransactionByTxnId(id)
             } ?: listOf()
             if (results.isEmpty()) {
                 writer.println("No Results")

--- a/shell/src/main/kotlin/net/corda/tools/shell/FlowStatusQueryCommand.kt
+++ b/shell/src/main/kotlin/net/corda/tools/shell/FlowStatusQueryCommand.kt
@@ -140,9 +140,7 @@ internal class FlowStatusQueryCommand : MultiRpcInteractiveShellCommand() {
         @Suppress("TooGenericExceptionCaught")
         fun queryFinalityById(writer: PrintWriter, input: List<String>?, ops: NodeFlowStatusRpcOps) {
             val results = input?.mapNotNull { id ->
-                ops.getFlowTransaction(id).apply {
-                    println(this)
-                }
+                ops.getFlowTransaction(id).apply { println(this) }
             } ?: listOf()
             if (results.isEmpty()) {
                 writer.println("No Results")
@@ -165,7 +163,7 @@ internal class FlowStatusQueryCommand : MultiRpcInteractiveShellCommand() {
         @Suppress("TooGenericExceptionCaught")
         fun queryFinalityByTxnId(writer: PrintWriter, input: List<String>?, ops: NodeFlowStatusRpcOps) {
             val results = input?.mapNotNull { id ->
-                ops.getFlowTransactionByTxnId(id)
+                ops.getFlowTransactionByTxnId(id).apply { println(this) }
             } ?: listOf()
             if (results.isEmpty()) {
                 writer.println("No Results")

--- a/shell/src/main/kotlin/net/corda/tools/shell/FlowStatusQueryCommand.kt
+++ b/shell/src/main/kotlin/net/corda/tools/shell/FlowStatusQueryCommand.kt
@@ -140,7 +140,7 @@ internal class FlowStatusQueryCommand : MultiRpcInteractiveShellCommand() {
         @Suppress("TooGenericExceptionCaught")
         fun queryFinalityById(writer: PrintWriter, input: List<String>?, ops: NodeFlowStatusRpcOps) {
             val results = input?.mapNotNull { id ->
-                ops.getFlowTransaction(id).apply { println(this) }
+                ops.getFlowTransactionInfo(id).apply { println(this) }
             } ?: listOf()
             if (results.isEmpty()) {
                 writer.println("No Results")
@@ -163,7 +163,7 @@ internal class FlowStatusQueryCommand : MultiRpcInteractiveShellCommand() {
         @Suppress("TooGenericExceptionCaught")
         fun queryFinalityByTxnId(writer: PrintWriter, input: List<String>?, ops: NodeFlowStatusRpcOps) {
             val results = input?.mapNotNull { id ->
-                ops.getFlowTransactionByTxnId(id)
+                ops.getFlowTransactionInfoByTxnId(id)
             } ?: listOf()
             if (results.isEmpty()) {
                 writer.println("No Results")

--- a/shell/src/main/kotlin/net/corda/tools/shell/utlities/FlowRecoveryParser.kt
+++ b/shell/src/main/kotlin/net/corda/tools/shell/utlities/FlowRecoveryParser.kt
@@ -1,0 +1,28 @@
+package net.corda.tools.shell.utlities
+
+import net.corda.client.jackson.StringToClassParser
+import net.corda.client.jackson.getOrReport
+import net.corda.client.rpc.proxy.FlowRPCOps
+import net.corda.core.flows.StateMachineRunId
+import net.corda.core.messaging.CordaRPCOps
+import net.corda.nodeapi.flow.hospital.FlowRecoveryQuery
+import net.corda.tools.shell.InteractiveShell
+import net.corda.tools.shell.flattenInput
+import java.io.PrintWriter
+
+fun queryRecoveryFlows(writer: PrintWriter, input: List<String>?, ops: FlowRPCOps, partyOps: CordaRPCOps, forceRecover: Boolean? = null): Map<StateMachineRunId, Boolean> {
+    val query = StringToClassParser(FlowRecoveryQuery::class.java)
+        .parse(input.flattenInput(), InteractiveShell.createYamlInputMapper(partyOps))
+        .getOrReport(writer)
+    val result = query?.let { q ->
+        forceRecover?.let { ops.recoverFinalityFlowsMatching(q, it) }
+            ?: ops.recoverFinalityFlowsMatching(q) }
+            ?: emptyMap()
+    result.forEach { id ->
+        writer.write("\t$id")
+    }
+    return result
+}
+
+fun queryRecoveryFlows(writer: PrintWriter, input: List<String>?, ops: FlowRPCOps, partyOps: CordaRPCOps) =
+    queryRecoveryFlows(writer, input, ops, partyOps, null)


### PR DESCRIPTION
Introduction of new shell commands which map into the new FlowRPCOps operations:

- `queryFinalityById`
   List finality flow transaction information by flow ID
- `queryFinalityByTxnId`
   List finality flow transaction information by transaction ID
- `recoverFinality` 
   Recover a finality flow by flow uuid.
- `recoverFinalityByTxnId`
   Recover a finality flow by transaction id.
- `recoverAllFinality`
   Recover all finality flows that have failed on this node.
- `recoverFinalityMatching` 
           `[flowStartFromTime: "ISO8601 DateTime"]` - the start of a time window where the flow was started
           `[flowStartUntilTime: "ISO8601 DateTime"] `- the end of a time window where the flow was started 
           `[initiatedBy: "X509 name"]` - the name of the party that initiated the flow (e.g. O=PartyA,L=London,C=GB)
           `[counterParties: "X509 name1, X509 name2, etc>"]` - the name of any counter party peers receiving the flow (can be specified as an array like [\"O=PartyA,L=London,C=GB\", \"O=PartyB,L=London,C=GB\"])

An optional [-f, --force-recover] flag may be passed to the above commands to force recovery of flows that are in a `HOSPITALIZED` or `PAUSED` state.