### PR TITLE
ENT-8917 - security vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,20 @@ allprojects {
     group 'net.corda'
     version rootProject.version
 
+    configurations {
+        all {
+            resolutionStrategy {
+                eachDependency { details ->
+                    if (details.requested.group == 'org.apache.sshd') {
+                        if (details.requested.name == "sshd-common") {
+                            details.useVersion sshdCommonVersion
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     repositories {
         mavenLocal()
         if (System.getenv("CORDA_USE_CACHE")) {
@@ -154,6 +168,8 @@ allprojects {
             allWarningsAsErrors = false
         }
     }
+
+    tasks.register("allDependencies", DependencyReportTask) {}
 }
 
 artifactory {

--- a/build.gradle
+++ b/build.gradle
@@ -168,8 +168,6 @@ allprojects {
             allWarningsAsErrors = false
         }
     }
-
-    tasks.register("allDependencies", DependencyReportTask) {}
 }
 
 artifactory {

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,7 @@ jschVersion=0.1.55
 gradlePluginsVersion=5.0.12
 mockitoVersion=2.28.2
 mockitoKotlinVersion=1.6.0
+sshdCommonVersion=2.9.2
 
 artifactoryPluginVersion=4.16.1
 artifactoryContextUrl=https://software.r3.com/artifactory


### PR DESCRIPTION
Upgraded sshd-common.

For manual testing, used the new corda shell to connect to a node and:

Ran some basic commands:
- run nodeInfo
- run nodeDiagnosticInfo

Did a simple flow test:
- Run the finance cordapp's issue-and-payments flow from node1 to node2

All ran OK.