### PR TITLE
ENT-8917 - reverted dependency change

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,20 +77,6 @@ allprojects {
     group 'net.corda'
     version rootProject.version
 
-    configurations {
-        all {
-            resolutionStrategy {
-                eachDependency { details ->
-                    if (details.requested.group == 'org.apache.sshd') {
-                        if (details.requested.name == "sshd-common") {
-                            details.useVersion sshdCommonVersion
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     repositories {
         mavenLocal()
         if (System.getenv("CORDA_USE_CACHE")) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,6 @@ jschVersion=0.1.55
 gradlePluginsVersion=5.0.12
 mockitoVersion=2.28.2
 mockitoKotlinVersion=1.6.0
-sshdCommonVersion=2.9.2
 
 artifactoryPluginVersion=4.16.1
 artifactoryContextUrl=https://software.r3.com/artifactory


### PR DESCRIPTION
Reverted the dependency change of sshd-common previously made to address security issues, as it caused automated test failures.
