### PR TITLE
INFRA-1957: groupId required by publish stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,6 +58,17 @@ pipeline {
     }
 
     stages {
+        stage('Read properties') {
+            steps {
+                script {
+                    def props = readProperties file: 'gradle.properties'
+                    groupId = props['cordaReleaseGroup']
+                    def artifactId = 'corda-shell'
+                    version = props['cordaShellReleaseVersion']
+                    echo "${groupId}-${artifactId}-${version}"
+                }
+            }
+        }
         stage('Snyk Security') {
             when {
                 expression { isRelease || isReleaseBranch }


### PR DESCRIPTION
As part of the previous commit removing Nexus IQ, the `groupId` variable was removed in error. Re adding stage to gather needed properties. 