### PR TITLE
ENT-11341 Update to use kotlin native utils and snapshot publish from release branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ killAllExistingBuildsForJob(env.JOB_NAME, env.BUILD_NUMBER.toInteger())
 
 boolean isReleaseBranch = (env.BRANCH_NAME =~ /^release\/.*/)
 boolean isReleaseTag = (env.TAG_NAME =~ /^release-.*/)
-boolean isRelease = isReleaseBranch || isReleaseTag
+boolean isRelease = isReleaseBranch
 
 boolean isOSReleaseBranch = (env.BRANCH_NAME =~ /^release\/os\/.*/)
 boolean isEntReleaseBranch = (env.BRANCH_NAME =~ /^release\/ent\/.*/)
@@ -13,7 +13,7 @@ boolean isOSReleaseTag = (env.BRANCH_NAME =~ /^release-OS-.*/)
 boolean isENTReleaseTag = (env.TAG_NAME =~ /^release-ENT-.*/)
 
 def buildEdition = (isOSReleaseTag) ? "Corda Community Edition" : "Corda Open Source"
-String publishOptions = isRelease ? "-s --info" : "--no-daemon -s -PversionFromGit"
+String publishOptions = (isRelease || isReleaseBranch) ? "-s --info" : "--no-daemon -s -PversionFromGit"
 String artifactoryBuildName = "Corda-Shell"
 
 // Artifactory build info links
@@ -40,7 +40,7 @@ pipeline {
     }
 
     parameters {
-        booleanParam defaultValue: isRelease, description: 'Publish artifacts to Artifactory?', name: 'DO_PUBLISH'
+        booleanParam defaultValue: isRelease || isReleaseBranch, description: 'Publish artifacts to Artifactory?', name: 'DO_PUBLISH'
     }
 
     triggers {

--- a/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
+++ b/shell/src/integration-test/kotlin/net/corda/tools/shell/InteractiveShellIntegrationTest.kt
@@ -22,10 +22,6 @@ import net.corda.core.flows.*
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.Party
 import net.corda.core.internal.concurrent.transpose
-import net.corda.core.internal.createDirectories
-import net.corda.core.internal.div
-import net.corda.core.internal.inputStream
-import net.corda.core.internal.list
 import net.corda.core.messaging.ClientRpcSslOptions
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.core.messaging.startFlow
@@ -75,6 +71,10 @@ import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeoutException
 import java.util.zip.ZipInputStream
 import javax.security.auth.x500.X500Principal
+import kotlin.io.path.createDirectories
+import kotlin.io.path.div
+import kotlin.io.path.inputStream
+import kotlin.io.path.listDirectoryEntries
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -308,7 +308,7 @@ class InteractiveShellIntegrationTest {
             alice.checkpointsRpc.use { InteractiveShell.runDumpCheckpoints(it) }
             ExternalOperation.lock2.release()
 
-            val zipFile = (alice.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME).list().first { "checkpoints_dump-" in it.toString() }
+            val zipFile = (alice.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME).listDirectoryEntries().first { "checkpoints_dump-" in it.toString() }
             val json = ZipInputStream(zipFile.inputStream()).use { zip ->
                 zip.nextEntry
                 ObjectMapper().readTree(zip)
@@ -330,7 +330,7 @@ class InteractiveShellIntegrationTest {
             ExternalAsyncOperation.lock.acquire()
             alice.checkpointsRpc.use { InteractiveShell.runDumpCheckpoints(it) }
             ExternalAsyncOperation.future.complete(null)
-            val zipFile = (alice.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME).list().first { "checkpoints_dump-" in it.toString() }
+            val zipFile = (alice.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME).listDirectoryEntries().first { "checkpoints_dump-" in it.toString() }
             val json = ZipInputStream(zipFile.inputStream()).use { zip ->
                 zip.nextEntry
                 ObjectMapper().readTree(zip)
@@ -357,7 +357,7 @@ class InteractiveShellIntegrationTest {
                 alice.rpc.startFlow(::WaitForStateConsumptionFlow, stateRefs).returnValue.getOrThrow(10.seconds)
             }
             alice.checkpointsRpc.use { InteractiveShell.runDumpCheckpoints(it) }
-            val zipFile = (alice.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME).list().first { "checkpoints_dump-" in it.toString() }
+            val zipFile = (alice.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME).listDirectoryEntries().first { "checkpoints_dump-" in it.toString() }
             val json = ZipInputStream(zipFile.inputStream()).use { zip ->
                 zip.nextEntry
                 ObjectMapper().readTree(zip)
@@ -398,7 +398,7 @@ class InteractiveShellIntegrationTest {
             mockRenderPrintWriter()
             aliceNode.checkpointsRpc.use { InteractiveShell.runDumpCheckpoints(it) }
 
-            val zipFile = (aliceNode.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME).list().first { "checkpoints_dump-" in it.toString() }
+            val zipFile = (aliceNode.baseDirectory / NodeStartup.LOGS_DIRECTORY_NAME).listDirectoryEntries().first { "checkpoints_dump-" in it.toString() }
             val json = ZipInputStream(zipFile.inputStream()).use { zip ->
                 zip.nextEntry
                 ObjectMapper().readTree(zip)

--- a/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -22,8 +22,6 @@ import net.corda.core.internal.Emoji
 import net.corda.core.internal.VisibleForTesting
 import net.corda.core.internal.concurrent.doneFuture
 import net.corda.core.internal.concurrent.openFuture
-import net.corda.core.internal.createDirectories
-import net.corda.core.internal.div
 import net.corda.core.internal.messaging.AttachmentTrustInfoRPCOps
 import net.corda.core.internal.packageName_
 import net.corda.core.internal.rootCause
@@ -75,6 +73,8 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Future
 import kotlin.concurrent.thread
+import kotlin.io.path.createDirectories
+import kotlin.io.path.div
 
 const val STANDALONE_SHELL_PERMISSION = "ALL"
 

--- a/shell/src/main/kotlin/net/corda/tools/shell/SerializationSupport.kt
+++ b/shell/src/main/kotlin/net/corda/tools/shell/SerializationSupport.kt
@@ -8,8 +8,6 @@ import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.google.common.io.Closeables
 import net.corda.core.contracts.UniqueIdentifier
-import net.corda.core.internal.copyTo
-import net.corda.core.internal.inputStream
 import org.crsh.command.InvocationContext
 import rx.Observable
 import java.io.BufferedInputStream
@@ -18,6 +16,8 @@ import java.nio.file.Paths
 import java.util.Collections
 import java.util.HashSet
 import java.util.UUID
+import kotlin.io.path.inputStream
+import kotlin.io.path.outputStream
 
 //region Extra serializers
 //
@@ -64,7 +64,7 @@ object InputStreamSerializer : JsonSerializer<InputStream>() {
                 gen.writeString("<not saved>")
             } else {
                 val path = Paths.get(toPath)
-                it.copyTo(path)
+                it.copyTo(path.outputStream())
                 gen.writeString("<saved to: ${path.toAbsolutePath()}>")
             }
         }

--- a/shell/src/main/kotlin/net/corda/tools/shell/standalone/ShellCmdLineOptions.kt
+++ b/shell/src/main/kotlin/net/corda/tools/shell/standalone/ShellCmdLineOptions.kt
@@ -2,7 +2,6 @@ package net.corda.tools.shell.standalone
 
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
-import net.corda.core.internal.div
 import net.corda.core.messaging.ClientRpcSslOptions
 import net.corda.core.utilities.NetworkHostAndPort
 import net.corda.nodeapi.internal.config.parseAs
@@ -11,6 +10,7 @@ import net.corda.tools.shell.ShellConfiguration.Companion.COMMANDS_DIR
 import picocli.CommandLine.Option
 import java.nio.file.Path
 import java.nio.file.Paths
+import kotlin.io.path.div
 
 class ShellCmdLineOptions {
     @Option(

--- a/shell/src/main/kotlin/net/corda/tools/shell/standalone/StandaloneShell.kt
+++ b/shell/src/main/kotlin/net/corda/tools/shell/standalone/StandaloneShell.kt
@@ -4,9 +4,6 @@ import com.jcabi.manifests.Manifests
 import net.corda.cliutils.CordaCliWrapper
 import net.corda.cliutils.ExitCodes
 import net.corda.cliutils.start
-import net.corda.core.internal.exists
-import net.corda.core.internal.isRegularFile
-import net.corda.core.internal.list
 import net.corda.core.utilities.contextLogger
 import net.corda.tools.shell.InteractiveShell
 import net.corda.tools.shell.ShellConfiguration
@@ -21,6 +18,9 @@ import java.net.URL
 import java.net.URLClassLoader
 import java.nio.file.Path
 import java.util.concurrent.CountDownLatch
+import kotlin.io.path.exists
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.listDirectoryEntries
 import kotlin.streams.toList
 
 fun main(args: Array<String>) {
@@ -50,9 +50,9 @@ D""".trimStart()
         if (cordappsDir == null || !cordappsDir.exists()) {
             emptyList()
         } else {
-            cordappsDir.list {
-                it.filter { it.isRegularFile() && it.toString().endsWith(".jar") }.map { it.toUri().toURL() }.toList()
-            }
+            cordappsDir.listDirectoryEntries().filter {
+                it.isRegularFile() && it.toString().endsWith(".jar")
+            }.map { it.toUri().toURL() }.toList()
         }
 
     //Workaround in case console is not available


### PR DESCRIPTION
This PR includes the following changes:

1. A number of Path and file related utilities have been removed from corda-core, this PR replaces those with native kotlin versions.
2. The logic for publishing snapshots from the release branch was incorrect, this has now been fixed. The nightly build will publish snapshos from the release branch. and release branch does not include the git tag info.