### PR TITLE
ES-1852: Ensure version string is inline with 4.11 and below

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,11 +140,11 @@ plugins {
 // If the command line project option -PversionFromGit is added to the gradle invocation, we'll resolve
 // the latest git commit hash and timestamp and create a version postfix from that
 if (project.hasProperty("versionFromGit")) {
-    ext.versionSuffix = "${grgit.head().dateTime.format("yyyyMMdd_HHmmss")}-${grgit.head().abbreviatedId}"
+    ext.versionSuffix = "-${grgit.head().dateTime.format("yyyyMMdd_HHmmss")}-${grgit.head().abbreviatedId}"
 }
 
 if (ext.versionSuffix != "") {
-    ext.release_version = "${ext.baseVersion}-${ext.versionSuffix}".toString()
+    ext.release_version = "${ext.baseVersion}${ext.versionSuffix}".toString()
 } else {
     ext.release_version = "${ext.baseVersion}".toString()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlin.code.style=official
 # this versionSuffix value sould be left blank for a release
 # all other times during normal development cycle this should be set to '-SNAPSHOT'
 baseVersion=4.12
-versionSuffix=SNAPSHOT
+versionSuffix=-SNAPSHOT
 
 # The version of Corda that the shell depends on
 # When creating a release build, this should be changed to point to a specific Corda version (e.g 4.9)


### PR DESCRIPTION
Our release automation pipeline which updates versions and tags projects, expects to find the hypen in the gradle properties.

I'm changing this to keep the same standard we have in 4.11 and below, as in the current format, while it works as intended in the standard CI, our release automation ends up creating a version as follows *-4.12--HC02.jar notice the double -.

modifying this back to the same pattern as 4.11 and below resolves this, as our automation caters to that already