### PR TITLE
ENT-11279 - FlowTimeWindow has moved

### DIFF
--- a/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
+++ b/shell/src/main/kotlin/net/corda/tools/shell/InteractiveShell.kt
@@ -18,7 +18,7 @@ import net.corda.core.concurrent.CordaFuture
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.contracts.UniqueIdentifier
 import net.corda.core.flows.FlowLogic
-import net.corda.core.flows.FlowTimeWindow
+import net.corda.nodeapi.flow.hospital.FlowTimeWindow
 import net.corda.core.flows.StateMachineRunId
 import net.corda.core.internal.Emoji
 import net.corda.core.internal.VisibleForTesting

--- a/shell/src/main/kotlin/net/corda/tools/shell/SerializationSupport.kt
+++ b/shell/src/main/kotlin/net/corda/tools/shell/SerializationSupport.kt
@@ -12,7 +12,7 @@ import com.google.common.io.Closeables
 import net.corda.client.jackson.internal.readValueAs
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.contracts.UniqueIdentifier
-import net.corda.core.flows.FlowTimeWindow
+import net.corda.nodeapi.flow.hospital.FlowTimeWindow
 import net.corda.core.internal.copyTo
 import net.corda.core.internal.inputStream
 import org.crsh.command.InvocationContext

--- a/shell/src/test/kotlin/net/corda/tools/shell/CustomTypeJsonParsingTests.kt
+++ b/shell/src/test/kotlin/net/corda/tools/shell/CustomTypeJsonParsingTests.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.module.kotlin.readValue
 import net.corda.core.contracts.TimeWindow
 import net.corda.core.contracts.UniqueIdentifier
-import net.corda.core.flows.FlowTimeWindow
+import net.corda.nodeapi.flow.hospital.FlowTimeWindow
 import org.junit.Before
 import org.junit.Test
 import java.time.Duration

--- a/shell/src/test/kotlin/net/corda/tools/shell/FlowStatusQueryCommandTest.kt
+++ b/shell/src/test/kotlin/net/corda/tools/shell/FlowStatusQueryCommandTest.kt
@@ -3,7 +3,7 @@ package net.corda.tools.shell
 import com.nhaarman.mockito_kotlin.argThat
 import com.nhaarman.mockito_kotlin.mock
 import net.corda.client.rpc.proxy.NodeFlowStatusRpcOps
-import net.corda.core.flows.FlowTimeWindow
+import net.corda.nodeapi.flow.hospital.FlowTimeWindow
 import net.corda.core.identity.CordaX500Name
 import net.corda.core.messaging.CordaRPCOps
 import net.corda.ext.api.flow.FlowStatusQueryProvider


### PR DESCRIPTION

4.11 broke compatibility by moving FlowTimeWindow package. This PR reverts the change, so now same as 4.10 and below.