### PR TITLE
ENT-11607 - Kotlin/JDK compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,8 +176,8 @@ allprojects {
     }
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
         kotlinOptions {
-            languageVersion = "1.8"
-            apiVersion = "1.8"
+            languageVersion = "1.9"
+            apiVersion = "1.9"
             jvmTarget = VERSION_17
             javaParameters = true   // Useful for reflection.
             freeCompilerArgs = ['-Xjvm-default=all-compatibility']

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ versionSuffix=-SNAPSHOT
 # When creating a release build, this should be changed to point to a specific Corda version (e.g 4.9)
 cordaReleaseVersion=4.12-SNAPSHOT
 cordaReleaseGroup=net.corda
-cordaPlatformVersion=14
+cordaPlatformVersion=140
 
 kotlinVersion=1.9.23
 crashVersion=1.7.6

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ artifactoryContextUrl=https://software.r3.com/artifactory
 publicArtifactURL=https://download.corda.net/maven
 kotlin.code.style=official
 
-# this versionSuffix value sould be left blank for a release
+# this versionSuffix value should be left blank for a release
 # all other times during normal development cycle this should be set to '-SNAPSHOT'
 baseVersion=4.12
 versionSuffix=-SNAPSHOT
@@ -13,7 +13,7 @@ cordaReleaseVersion=4.12-SNAPSHOT
 cordaReleaseGroup=net.corda
 cordaPlatformVersion=14
 
-kotlinVersion=1.9.0
+kotlinVersion=1.9.23
 crashVersion=1.7.6
 sshdCoreVersion=2.10.0
 quasar_version=0.9.0_r3

--- a/shell/build.gradle
+++ b/shell/build.gradle
@@ -158,6 +158,8 @@ integrationTest {
             '--add-opens', 'java.base/java.util.concurrent=ALL-UNNAMED', '--add-opens', 'java.sql/java.sql=ALL-UNNAMED',
             '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
             '--add-opens', 'java.base/java.security=ALL-UNNAMED',
+            '--add-opens', 'java.base/sun.security.x509=ALL-UNNAMED',
+            '--add-opens', 'java.base/sun.security.util=ALL-UNNAMED',
             '--add-opens', 'jdk.crypto.ec/sun.security.ec.ed=ALL-UNNAMED',
             '--add-exports', 'java.base/sun.nio.ch=ALL-UNNAMED'
     ]

--- a/shell/build.gradle
+++ b/shell/build.gradle
@@ -157,9 +157,14 @@ integrationTest {
             '--add-opens', 'java.base/java.security.cert=ALL-UNNAMED', '--add-opens', 'java.base/javax.net.ssl=ALL-UNNAMED',
             '--add-opens', 'java.base/java.util.concurrent=ALL-UNNAMED', '--add-opens', 'java.sql/java.sql=ALL-UNNAMED',
             '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.security=ALL-UNNAMED',
+            '--add-opens', 'jdk.crypto.ec/sun.security.ec.ed=ALL-UNNAMED',
             '--add-exports', 'java.base/sun.nio.ch=ALL-UNNAMED'
     ]
 }
+
+
+
 
 publishing {
     publications {

--- a/shell/build.gradle
+++ b/shell/build.gradle
@@ -151,22 +151,23 @@ test {
 
 integrationTest {
     jvmArgs += [
-            '--add-opens', 'java.base/java.time=ALL-UNNAMED', '--add-opens', 'java.base/java.io=ALL-UNNAMED',
-            '--add-opens', 'java.base/java.util=ALL-UNNAMED', '--add-opens', 'java.base/java.net=ALL-UNNAMED',
-            '--add-opens', 'java.base/java.nio=ALL-UNNAMED', '--add-opens', 'java.base/java.lang.invoke=ALL-UNNAMED',
-            '--add-opens', 'java.base/java.security.cert=ALL-UNNAMED', '--add-opens', 'java.base/javax.net.ssl=ALL-UNNAMED',
-            '--add-opens', 'java.base/java.util.concurrent=ALL-UNNAMED', '--add-opens', 'java.sql/java.sql=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.time=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.io=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.util=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.net=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.nio=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.lang.invoke=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.security.cert=ALL-UNNAMED',
+            '--add-opens', 'java.base/javax.net.ssl=ALL-UNNAMED',
+            '--add-opens', 'java.base/java.util.concurrent=ALL-UNNAMED',
+            '--add-opens', 'java.sql/java.sql=ALL-UNNAMED',
             '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
             '--add-opens', 'java.base/java.security=ALL-UNNAMED',
             '--add-opens', 'java.base/sun.security.x509=ALL-UNNAMED',
             '--add-opens', 'java.base/sun.security.util=ALL-UNNAMED',
-            '--add-opens', 'jdk.crypto.ec/sun.security.ec.ed=ALL-UNNAMED',
-            '--add-exports', 'java.base/sun.nio.ch=ALL-UNNAMED'
+            '--add-opens', 'jdk.crypto.ec/sun.security.ec.ed=ALL-UNNAMED'
     ]
 }
-
-
-
 
 publishing {
     publications {


### PR DESCRIPTION
Tests were previously failing with errors like this:

`Unable to load CorDapp /Users/chris.cochrane/dev/git/corda/corda-shell/shell/build/node-driver/20240308-095001.060-908F4AD1C9C04C13/AliceCorp/cordapps/custom-cordapp_1_140_f9f3b6e7-1c56-428a-813e-dc86624da8ca.jar: Unsupported Kotlin metadata version 1.8.0`

The Kotlin options in `build.gradle `have been updated from 1.8 to 1.9 to resolve this.

Subsequently, it was discovered that tests would then fail with error of the type:

`Unable to make protected <method> accessible: module <module name> does not opens <package name> to unnamed module <address>
`
These are resolved by extending the list of `--add-opens` arguments for the integration test JVM args.

Note that the development of this PR revealed an issue with the standalone shell, which will be investigated and resolved in a subsequent PR:
[ENT-11612 "Standalone shell running in Safe mode"](https://r3-cev.atlassian.net/browse/ENT-11612)