### PR TITLE
ENT-11353: reverted to single cordaReleaseVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -262,7 +262,7 @@ allprojects {
     tasks.withType(Jar).configureEach { task ->
         // Includes War and Ear
         manifest {
-            attributes('Corda-Release-Version': cordaOSReleaseVersion)
+            attributes('Corda-Release-Version': cordaReleaseVersion)
             attributes('Corda-Platform-Version': cordaPlatformVersion)
             attributes('Corda-Revision': cordaRevision)
             attributes('Corda-Vendor': cordaBuildEdition)

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,10 +7,9 @@ kotlin.code.style=official
 baseVersion=4.12
 versionSuffix=-SNAPSHOT
 
-# The version of Corda that the shell depends on
+# The version of Corda that the shell depends on, this is the same version for os and enterprise.
 # When creating a release build, this should be changed to point to a specific Corda version (e.g 4.9)
-cordaOSReleaseVersion=4.12-SNAPSHOT
-cordaEntReleaseVersion=4.12-SNAPSHOT
+cordaReleaseVersion=4.12-SNAPSHOT
 cordaReleaseGroup=com.r3.corda
 cordaOpenSourceReleaseGroup=net.corda
 cordaPlatformVersion=140

--- a/shell/build.gradle
+++ b/shell/build.gradle
@@ -35,13 +35,13 @@ sourceSets {
 
 dependencies {
 
-    implementation "net.corda:corda-core:$cordaOSReleaseVersion"
-    implementation "$cordaReleaseGroup:corda-node-api:$cordaEntReleaseVersion"
+    implementation "net.corda:corda-core:$cordaReleaseVersion"
+    implementation "$cordaReleaseGroup:corda-node-api:$cordaReleaseVersion"
 
-    implementation "$cordaReleaseGroup:corda-rpc:$cordaEntReleaseVersion"
-    implementation "$cordaReleaseGroup:corda-tools-cliutils:$cordaEntReleaseVersion"
-    implementation "$cordaReleaseGroup:corda-common-logging:$cordaEntReleaseVersion"
-    implementation "$cordaReleaseGroup:corda-common-configuration-parsing:$cordaEntReleaseVersion"
+    implementation "$cordaReleaseGroup:corda-rpc:$cordaReleaseVersion"
+    implementation "$cordaReleaseGroup:corda-tools-cliutils:$cordaReleaseVersion"
+    implementation "$cordaReleaseGroup:corda-common-logging:$cordaReleaseVersion"
+    implementation "$cordaReleaseGroup:corda-common-configuration-parsing:$cordaReleaseVersion"
 
     implementation "io.reactivex:rxjava:$rxjavaVersion"
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
@@ -54,7 +54,7 @@ dependencies {
     implementation "org.apache.activemq:artemis-commons:$artemisVersion"
 
     // Jackson support: serialisation to/from JSON, YAML, etc.
-    implementation "$cordaReleaseGroup:corda-jackson:$cordaEntReleaseVersion"
+    implementation "$cordaReleaseGroup:corda-jackson:$cordaReleaseVersion"
 
     // Bouncy castle support needed for X509 certificate manipulation
     testImplementation "org.bouncycastle:bcprov-debug-jdk18on:${bouncycastleVersion}"
@@ -67,11 +67,11 @@ dependencies {
 
     testRuntimeOnly "org.iq80.snappy:snappy:$snappyVersion"
 
-    implementation "$cordaReleaseGroup:corda-extensions-api:$cordaEntReleaseVersion"
-    implementation "$cordaReleaseGroup:corda-rpc-ext:$cordaEntReleaseVersion"
+    implementation "$cordaReleaseGroup:corda-extensions-api:$cordaReleaseVersion"
+    implementation "$cordaReleaseGroup:corda-rpc-ext:$cordaReleaseVersion"
 
-    implementation "$cordaReleaseGroup:corda-extensions-api:$cordaEntReleaseVersion"
-    implementation "$cordaReleaseGroup:corda-rpc-ext:$cordaEntReleaseVersion"
+    implementation "$cordaReleaseGroup:corda-extensions-api:$cordaReleaseVersion"
+    implementation "$cordaReleaseGroup:corda-rpc-ext:$cordaReleaseVersion"
 
     // CRaSH: An embeddable monitoring and admin shell with support for adding new commands written in Groovy.
     implementation("org.crashub:crash.shell:$crashVersion") {
@@ -104,9 +104,9 @@ dependencies {
 
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
 
-    testImplementation "$cordaReleaseGroup:corda-extensions-node:$cordaEntReleaseVersion"
+    testImplementation "$cordaReleaseGroup:corda-extensions-node:$cordaReleaseVersion"
 
-    testImplementation "$cordaReleaseGroup:corda-extensions-node:$cordaEntReleaseVersion"
+    testImplementation "$cordaReleaseGroup:corda-extensions-node:$cordaReleaseVersion"
 
     testImplementation "junit:junit:$junitVersion"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$junitVintageVersion"
@@ -115,17 +115,17 @@ dependencies {
 
     // Unit testing helpers.
     testImplementation "org.assertj:assertj-core:$assertJVersion"
-    testImplementation "$cordaReleaseGroup:corda-node:$cordaEntReleaseVersion"
-    testImplementation "$cordaReleaseGroup:corda-core-test-utils:$cordaEntReleaseVersion"
-    testImplementation "$cordaReleaseGroup:corda-test-utils:$cordaEntReleaseVersion"
-    testImplementation "$cordaReleaseGroup:corda-jackson:$cordaEntReleaseVersion"
+    testImplementation "$cordaReleaseGroup:corda-node:$cordaReleaseVersion"
+    testImplementation "$cordaReleaseGroup:corda-core-test-utils:$cordaReleaseVersion"
+    testImplementation "$cordaReleaseGroup:corda-test-utils:$cordaReleaseVersion"
+    testImplementation "$cordaReleaseGroup:corda-jackson:$cordaReleaseVersion"
     testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
 
     // Jsh: Testing SSH server.
     integrationTestImplementation "com.jcraft:jsch:$jschVersion"
 
-    integrationTestImplementation "$cordaReleaseGroup:corda-node-driver:$cordaEntReleaseVersion"
-    integrationTestImplementation "$cordaReleaseGroup:corda-test-utils:$cordaEntReleaseVersion"
+    integrationTestImplementation "$cordaReleaseGroup:corda-node-driver:$cordaReleaseVersion"
+    integrationTestImplementation "$cordaReleaseGroup:corda-test-utils:$cordaReleaseVersion"
     integrationTestImplementation project(':test-cordapps:failing-flows:workflows')
 
     integrationTestRuntimeOnly "org.apache.sshd:sshd-core:$sshdCoreVersion"
@@ -156,7 +156,7 @@ shadowJar {
     archiveClassifier = ''
     mergeServiceFiles()
     manifest {
-        attributes "Corda-Release-Version": cordaOSReleaseVersion
+        attributes "Corda-Release-Version": cordaReleaseVersion
         attributes('Corda-Platform-Version': cordaPlatformVersion)
         attributes "Corda-Vendor": "Corda Enterprise Edition"
     }

--- a/standalone-shell/build.gradle
+++ b/standalone-shell/build.gradle
@@ -39,7 +39,7 @@ shadowJar {
     archiveClassifier = ''
     mergeServiceFiles()
     manifest {
-        attributes "Corda-Release-Version": cordaOSReleaseVersion
+        attributes "Corda-Release-Version": cordaReleaseVersion
         attributes('Corda-Platform-Version': cordaPlatformVersion)
         attributes "Corda-Vendor": cordaBuildEdition
         attributes('Add-Opens': 'java.base/java.lang java.base/java.time java.base/java.io java.base/java.util')

--- a/test-cordapps/failing-flows/workflows/build.gradle
+++ b/test-cordapps/failing-flows/workflows/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
 
     // Corda integration dependencies
-    cordaProvided "$cordaOpenSourceReleaseGroup:corda-core:$cordaOSReleaseVersion"
+    cordaProvided "$cordaOpenSourceReleaseGroup:corda-core:$cordaReleaseVersion"
 }
 
 cordapp {


### PR DESCRIPTION
this only affects release/ent/4.12... versions of this repository
CC: @ronanbrowne