### PR TITLE
ES-2674: Ensure corda-shell is accurately scanned in the C4 release packs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,8 +157,8 @@ allprojects {
 }
 
 
-// Publish the default jar for all submodules, These are not for external consumtion.
-// We must generate a jar which has a pom.xml with a full dependency list for snyk to evaluate.
+// Publish the default jar for all submodules, These are not for external consumption.
+// We must generate a jar which has a pom.xml with a full dependency list for Snyk to evaluate.
 // The shadow jar removes this information, as those dependencies are embedded in the jar. 
 subprojects {
     afterEvaluate { project ->

--- a/build.gradle
+++ b/build.gradle
@@ -180,7 +180,7 @@ subprojects {
 
 
             jar {
-                archiveClassifier = 'r3-internal'
+                archiveClassifier = 'R3-internal'
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -156,6 +156,10 @@ allprojects {
     }
 }
 
+
+// Publish the default jar for all submodules, These are not for external consumtion.
+// We must generate a jar which has a pom.xml with a full dependency list for snyk to evaluate.
+// The shadow jar removes this information, as those dependencies are embedded in the jar. 
 subprojects {
     afterEvaluate { project ->
         if (project.name in ['shell', 'standalone-shell']) {
@@ -176,7 +180,7 @@ subprojects {
 
 
             jar {
-                archiveClassifier = 'internal'
+                archiveClassifier = 'r3-internal'
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -198,7 +198,8 @@ artifactory {
         defaults {
             // Root project applies the plugin (for this block) but does not need to be published
             if (project != rootProject) {
-                publications(project.extensions.publish.name())
+                def pubNames = project.publishing.publications*.name
+                publications(pubNames.toArray(new String[0]))
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -156,6 +156,32 @@ allprojects {
     }
 }
 
+subprojects {
+    afterEvaluate { project ->
+        if (project.name in ['shell', 'standalone-shell']) {
+            apply plugin: 'maven-publish'
+
+            publishing {
+                publications {
+                    "${project.name}-jarPublication"(MavenPublication) {
+                        from components.java
+                        artifactId = "corda-${project.name}-snyk-scanner"
+                        pom {
+                            name = "corda-${project.name}-snyk-scanner"
+                            description = "Corda ${project.name} for use with Snyk"
+                        }
+                    }
+                }
+            }
+
+
+            jar {
+                archiveClassifier = 'internal'
+            }
+        }
+    }
+}
+
 artifactory {
     publish {
         contextUrl = artifactoryContextUrl

--- a/shell/build.gradle
+++ b/shell/build.gradle
@@ -96,10 +96,6 @@ task integrationTest(type: Test) {
     classpath = sourceSets.integrationTest.runtimeClasspath
 }
 
-jar {
-    archiveClassifier = 'ignore'
-}
-
 shadowJar {
     archiveBaseName = 'corda-shell'
     archiveClassifier = ''
@@ -123,17 +119,4 @@ artifacts {
 publish {
     dependenciesFrom configurations.cordaShellDependencies
     name shadowJar.archiveBaseName
-}
-
-publishing {
-publications {
-    jarPublication(MavenPublication) {
-        from components.java
-        artifactId = 'corda-shell-snyk-scanner'
-        pom {
-            name = 'corda-shell-snyk-scanner'
-            description = 'Corda Shell for use with Snyk'
-        }
-    }
-}
 }

--- a/shell/build.gradle
+++ b/shell/build.gradle
@@ -97,7 +97,6 @@ task integrationTest(type: Test) {
 }
 
 jar {
-    enabled = false
     archiveClassifier = 'ignore'
 }
 
@@ -124,5 +123,17 @@ artifacts {
 publish {
     dependenciesFrom configurations.cordaShellDependencies
     name shadowJar.archiveBaseName
-    disableDefaultJar = true
+}
+
+publishing {
+publications {
+    jarPublication(MavenPublication) {
+        from components.java
+        artifactId = 'corda-shell-snyk-scanner'
+        pom {
+            name = 'corda-shell-snyk-scanner'
+            description = 'Corda Shell for use with Snyk'
+        }
+    }
+}
 }

--- a/standalone-shell/build.gradle
+++ b/standalone-shell/build.gradle
@@ -50,5 +50,4 @@ artifacts {
 publish {
     dependenciesFrom configurations.cordaShellDependencies
     name shadowJar.archiveBaseName
-    disableDefaultJar = true
 }

--- a/standalone-shell/build.gradle
+++ b/standalone-shell/build.gradle
@@ -31,11 +31,6 @@ tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << '-proc:none'
 }
 
-jar {
-    enabled = false
-    archiveClassifier = 'ignore'
-}
-
 shadowJar {
     archiveBaseName = 'corda-standalone-shell'
     archiveClassifier = ''


### PR DESCRIPTION
- Publish default jar for both subprojects , which has a full dependencies block in `pom.xml`
- We will only use this for the purpose of security scanning in the downstream release pack project.
    - This will only scan these Jars and not package them for publishing 
- "standard" shadow jar is unaffected, so as far as external consumers are concerned this is a non-functional change 