### PR TITLE
ES-2674: Ensure corda-shell is accurately scanned in the C4 release packs 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,3 +224,32 @@ ext.configureCommonPom = { pom ->
         }
     }
 }
+
+// Publish the default jar for all submodules, These are not for external consumption.
+// We must generate a jar which has a pom.xml with a full dependency list for Snyk to evaluate.
+// The shadow jar removes this information, as those dependencies are embedded in the jar. 
+subprojects {
+    afterEvaluate { project ->
+        if (project.name in ['shell', 'standalone-shell']) {
+            apply plugin: 'maven-publish'
+
+            publishing {
+                publications {
+                    "${project.name}-jarPublication"(MavenPublication) {
+                        from components.java
+                        artifactId = "corda-${project.name}-snyk-scanner"
+                        pom {
+                            name = "corda-${project.name}-snyk-scanner"
+                            description = "Corda ${project.name} for use with Snyk"
+                        }
+                    }
+                }
+            }
+
+
+            jar {
+                archiveClassifier = 'R3-internal'
+            }
+        }
+    }
+}

--- a/shell/build.gradle
+++ b/shell/build.gradle
@@ -125,11 +125,6 @@ task integrationTest(type: Test) {
     classpath = sourceSets.integrationTest.runtimeClasspath
 }
 
-jar {
-    enabled = false
-    archiveClassifier = 'ignore'
-}
-
 shadowJar {
     archiveBaseName = 'corda-shell'
     archiveClassifier = ''

--- a/standalone-shell/build.gradle
+++ b/standalone-shell/build.gradle
@@ -29,12 +29,6 @@ tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << '-proc:none'
 }
 
-
-jar {
-    enabled = false
-    archiveClassifier = 'ignore'
-}
-
 shadowJar {
     archiveBaseName = 'corda-standalone-shell'
     archiveClassifier = ''


### PR DESCRIPTION
Publish default jar for both subprojects , which has a full dependencies block in pom.xml We will only use this for the purpose of security scanning in the downstream release pack project. This will only scan these Jars and not package them for publishing "standard" shadow jar is unaffected, so as far as external consumers are concerned this is a non-functional change