### PR TITLE
ES-2674: Ensure corda-shell is accurately scanned in the C4 release packs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -274,7 +274,37 @@ artifactory {
         defaults {
             // Root project applies the plugin (for this block) but does not need to be published
             if (project != rootProject) {
-                publications(project.extensions.publish.name())
+                def pubNames = project.publishing.publications*.name
+                publications(pubNames.toArray(new String[0]))
+            }
+        }
+    }
+}
+
+// Publish the default jar for all submodules, These are not for external consumption.
+// We must generate a jar which has a pom.xml with a full dependency list for Snyk to evaluate.
+// The shadow jar removes this information, as those dependencies are embedded in the jar. 
+subprojects {
+    afterEvaluate { project ->
+        if (project.name in ['shell', 'standalone-shell']) {
+            apply plugin: 'maven-publish'
+
+            publishing {
+                publications {
+                    "${project.name}-jarPublication"(MavenPublication) {
+                        from components.java
+                        artifactId = "corda-${project.name}-snyk-scanner"
+                        pom {
+                            name = "corda-${project.name}-snyk-scanner"
+                            description = "Corda ${project.name} for use with Snyk"
+                        }
+                    }
+                }
+            }
+
+
+            jar {
+                archiveClassifier = 'R3-internal'
             }
         }
     }

--- a/shell/build.gradle
+++ b/shell/build.gradle
@@ -103,11 +103,6 @@ task integrationTest(type: Test) {
     classpath = sourceSets.integrationTest.runtimeClasspath
 }
 
-jar {
-    enabled = false
-    archiveClassifier = 'ignore'
-}
-
 shadowJar {
     archiveBaseName = 'corda-shell'
     archiveClassifier = ''
@@ -131,5 +126,4 @@ artifacts {
 publish {
     dependenciesFrom configurations.cordaShellDependencies
     name shadowJar.archiveBaseName
-    disableDefaultJar = true
 }

--- a/standalone-shell/build.gradle
+++ b/standalone-shell/build.gradle
@@ -31,11 +31,6 @@ tasks.withType(JavaCompile).configureEach {
     options.compilerArgs << '-proc:none'
 }
 
-jar {
-    enabled = false
-    archiveClassifier = 'ignore'
-}
-
 shadowJar {
     archiveBaseName = 'corda-standalone-shell'
     archiveClassifier = ''
@@ -55,5 +50,4 @@ artifacts {
 publish {
     dependenciesFrom configurations.cordaShellDependencies
     name shadowJar.archiveBaseName
-    disableDefaultJar = true
 }


### PR DESCRIPTION
Publish default jar for both subprojects , which has a full dependencies block in pom.xml
We will only use this for the purpose of security scanning in the downstream release pack project.
This will only scan these Jars and not package them for publishing
"standard" shadow jar is unaffected, so as far as external consumers are concerned, this is a non-functional change