### PR TITLE
ENT-12884 - Tidied up version config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -226,7 +226,7 @@ ext.configureCommonPom = { pom ->
 }
 
 // Publish the default jar for all submodules, These are not for external consumption.
-// We must generate a jar which has a pom.xml with a full dependency list for Snyk to evaluate.
+// We must generate a jar which has a pom.xml with a full dependency list for vulnerability tools to evaluate.
 // The shadow jar removes this information, as those dependencies are embedded in the jar. 
 subprojects {
     afterEvaluate { project ->
@@ -237,10 +237,10 @@ subprojects {
                 publications {
                     "${project.name}-jarPublication"(MavenPublication) {
                         from components.java
-                        artifactId = "corda-${project.name}-snyk-scanner"
+                        artifactId = "corda-${project.name}-thin-with-deps"
                         pom {
-                            name = "corda-${project.name}-snyk-scanner"
-                            description = "Corda ${project.name} for use with Snyk"
+                            name = "corda-${project.name}-thin-with-deps"
+                            description = "Corda ${project.name} for vulnerability checking"
                         }
                     }
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,13 @@ kotlin.code.style=official
 
 # this versionSuffix value should be left blank for a release
 # all other times during normal development cycle this should be set to '-SNAPSHOT'
-baseVersion=4.13
+cordaShellReleaseVersion=4.13
 versionSuffix=-SNAPSHOT
 
 # The version of Corda that the shell depends on
 # When creating a release build, this should be changed to point to a specific Corda version (e.g 4.9)
 cordaReleaseVersion=4.12-RC01
 cordaReleaseGroup=net.corda
-cordaShellReleaseVersion=4.13
 cordaPlatformVersion=141
 kotlinVersion=1.9.23
 crashVersion=1.7.6


### PR DESCRIPTION
This project uses `cordaShellReleaseVersion` to determine the publication version.
`baseVersion` is not actually used, and has been removed. This caused confusion in previous versions.

Also, renamed the scannable jars produced by this build, in line with the previous versions.