### PR TITLE
ENT-12884 - Corrected publish version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,14 +4,13 @@ kotlin.code.style=official
 
 # this versionSuffix value should be left blank for a release
 # all other times during normal development cycle this should be set to '-SNAPSHOT'
-baseVersion=4.12
+cordaShellReleaseVersion=4.12
 versionSuffix=-SNAPSHOT
 
 # The version of Corda that the shell depends on, this is the same version for os and enterprise.
 # When creating a release build, this should be changed to point to a specific Corda version (e.g 4.9)
 cordaReleaseVersion=4.12-SNAPSHOT
 cordaReleaseGroup=com.r3.corda
-cordaShellReleaseVersion=4.12.1
 cordaOpenSourceReleaseGroup=net.corda
 cordaPlatformVersion=140
 


### PR DESCRIPTION
Corrected the publish version for this project.
This project uses `cordaShellReleaseVersion` to determine the publication version.
`baseVersion` is not actually used, and has been removed.