### PR TITLE
ENT-13238 - Updated crash version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,11 +9,11 @@ versionSuffix=-SNAPSHOT
 
 # The version of Corda that the shell depends on
 # When creating a release build, this should be changed to point to a specific Corda version (e.g 4.9)
-cordaReleaseVersion=4.12-RC01
+cordaReleaseVersion=4.12-SNAPSHOT
 cordaReleaseGroup=net.corda
 cordaPlatformVersion=140
 kotlinVersion=1.9.23
-crashVersion=1.7.6
+crashVersion=1.7.7
 sshdCoreVersion=2.13.0_r3
 quasar_version=0.9.1_r3
 bouncycastleVersion=1.73


### PR DESCRIPTION
Updated the version of Crash, to a version that resolves https://github.com/advisories/GHSA-76h9-2vwh-w278 / SNYK-JAVA-ORGAPACHEMINA-8549507.