### PR TITLE
ENT-12932 - Updated crash version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ cordaOpenSourceReleaseGroup=net.corda
 cordaPlatformVersion=11
 
 kotlinVersion=1.2.71
-crashVersion=1.7.6
+crashVersion=1.7.7
 jansiVersion=1.18
 log4jVersion=2.17.1
 slf4jVersion=1.7.30


### PR DESCRIPTION
Updated the version of Crash, to a version that resolves CVE-2024-52046 / SNYK-JAVA-ORGAPACHEMINA-8549507.