### PR TITLE
ENT-12932 - Updated crash version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ cordaOpenSourceReleaseGroup=net.corda
 cordaPlatformVersion=140
 
 kotlinVersion=1.9.23
-crashVersion=1.7.6
+crashVersion=1.7.7
 sshdCoreVersion=2.13.0_r3
 quasarVersion=0.9.1_r3
 bouncycastleVersion=1.73


### PR DESCRIPTION
Updated the version of Crash, to a version that resolves CVE-2024-52046 / SNYK-JAVA-ORGAPACHEMINA-8549507.