### PR TITLE
ENT-13054 - Security dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -238,6 +238,21 @@ allprojects {
             attributes('Automatic-Module-Name': "net.corda.${task.project.name.replaceAll('-', '.')}")
         }
     }
+
+    configurations {
+        configureEach {
+            resolutionStrategy {
+                eachDependency { details ->
+                    // SNYK-JAVA-ORGAPACHESSHD-7676258 / CVE-2024-41909
+                    // SNYK-JAVA-ORGAPACHESSHD-3121053 / CVE-2022-45047
+                    // SNYK-JAVA-ORGAPACHESSHD-1316688 / CVE-2021-30129
+                    if (details.requested.group == 'org.apache.sshd' && details.requested.name == 'sshd-core') {
+                        details.useVersion sshdCoreVersion
+                    }
+                }
+            }
+        }
+    }
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@ cordaPlatformVersion=11
 
 kotlinVersion=1.2.71
 crashVersion=1.7.7
+sshdCoreVersion=2.13.0_r3
 jansiVersion=1.18
 log4jVersion=2.17.1
 slf4jVersion=1.7.30


### PR DESCRIPTION
Forced the version of sshd-core, to address security issues.