### PR TITLE
ENT-14752 - Security dependency update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ versionSuffix=-SNAPSHOT
 
 # The version of Corda that the shell depends on
 # When creating a release build, this should be changed to point to a specific Corda version (e.g 4.9)
-cordaReleaseVersion=4.13-RC03
+cordaReleaseVersion=4.13-SNAPSHOT
 cordaReleaseGroup=net.corda
 cordaPlatformVersion=150
 kotlinVersion=1.9.23


### PR DESCRIPTION
Updated the Corda OS reference to SNAPSHOT so that Corda shell picks up the transitive dependencies from the latest Corda, and doesn't report security issues that have been fixed in the latest version of Corda.
Of course, this will be updated to the"current" version of Corda when we're actually making an RC/GA build.