### PR TITLE
ENT-0: added forward merge

### DIFF
--- a/.ci/JenkinsfileMergeAutomation
+++ b/.ci/JenkinsfileMergeAutomation
@@ -1,0 +1,33 @@
+#! groovy
+@Library('corda-shared-build-pipeline-steps@5.3') _
+
+/*
+ * Forward merge any changes in current branch to the branch with following version.
+ *
+ * Please note, the branches names are intentionally separated as variables, to minimised conflicts
+ * during automated merges for this file.
+ *
+ * These variables should be updated when a new version is cut
+ */
+
+/**
+ * the branch name of origin branch, it should match the current branch
+ * and it acts as a fail-safe inside {@code forwardMerger} pipeline
+ */
+String originBranch = 'release/ent/4.9'
+
+/**
+ * the branch name of target branch, it should be the branch with the next version
+ * after the one in current branch.
+ */
+String targetBranch = 'release/ent/4.10'
+
+/**
+ * Forward merge any changes between {@code originBranch} and {@code targetBranch}
+ */
+forwardMerger(
+    targetBranch: targetBranch,
+    originBranch: originBranch,
+    slackChannel: '#c4-ent-forward-merge-bot-notifications',
+    cloneTickets: true,
+)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,6 @@ pipeline {
     options {
         timestamps()
         ansiColor('xterm')
-        overrideIndexTriggers(false)
         timeout(time: 1, unit: 'HOURS')
         buildDiscarder(logRotator(daysToKeepStr: '14', artifactDaysToKeepStr: '14'))
     }


### PR DESCRIPTION
* new pipeline to automatically create forward merge pull requests
* remove `overrideIndexTriggers` option from the main branch, which stops Jenkins from automatically start new build when there is a new commit or pull request