### PR TITLE
ES-2632: fix pom and javaDoc for external publishing (4.13)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,6 +229,12 @@ ext.configureCommonPom = { pom ->
 // We must generate a jar which has a pom.xml with a full dependency list for vulnerability tools to evaluate.
 // The shadow jar removes this information, as those dependencies are embedded in the jar. 
 subprojects {
+    plugins.withId("java") {
+        java {
+            withSourcesJar()
+        }
+    }
+
     afterEvaluate { project ->
         if (project.name in ['shell', 'standalone-shell']) {
             apply plugin: 'maven-publish'

--- a/shell/build.gradle
+++ b/shell/build.gradle
@@ -170,9 +170,12 @@ publishing {
             artifactId 'corda-shell'
             artifact(shadowJar)
             artifact(tasks.named("javadocJar"))
+            artifact(tasks.named("sourcesJar"))
 
             pom {
                 rootProject.configureCommonPom(delegate)
+                name = "corda-${project.name}"
+                description = "Corda ${project.name} optional driver"
             }
         }
     }

--- a/standalone-shell/build.gradle
+++ b/standalone-shell/build.gradle
@@ -47,9 +47,12 @@ publishing {
             artifactId = 'corda-standalone-shell'
             artifact(shadowJar)
             artifact(tasks.named("javadocJar"))
+            artifact(tasks.named("sourcesJar"))
 
             pom {
                 rootProject.configureCommonPom(delegate)
+                name = "corda-${project.name}"
+                description = "Corda ${project.name} optional driver"
             }
         }
     }


### PR DESCRIPTION
- javadoc publishing was lost in 4.13
- Pom meta data also missing
- both of these are needed for maven publishing
- implementing same change as in #118