### PR TITLE
ENT-15121 - Security dependency updates - ENT 4.11

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.25.0
+version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-JAVA-IONETTY-1042268:
@@ -18,22 +18,22 @@ ignore:
   SNYK-JAVA-ORGJETBRAINSKOTLIN-2628385:
     - '*':
         reason: >-
-          This is a build time vulnerability. It relates to the inability to
-          lock dependencies for Kotlin Multiplatform Gradle Projects. At build
-          time for Corda we do not use Multiplatform Gradle Projects so are not
-          affected by this vulnerability. In addition as it is a build time
-          vulnerability released artifacts are not affected.
-        expires: 2023-06-28T11:52:35.855Z
-        created: 2022-12-13T11:52:35.870Z
+          CVE-2022-24329: This is a build time vulnerability. It relates to the
+          inability to lock dependencies for Kotlin Multiplatform Gradle
+          Projects. At build time for Corda we do not use Multiplatform Gradle
+          Projects so are not affected by this vulnerability. In addition as it
+          is a build time vulnerability released artifacts are not affected.
+        expires: 2029-08-01T00:00:00.000Z
+        created: 2026-06-23T08:50:40.586Z
   SNYK-JAVA-ORGJETBRAINSKOTLIN-2393744:
     - '*':
         reason: >-
-          This vulnerability relates to information exposure via creation of
-          temporary files (via Kotlin functions) with insecure permissions.
-          Corda does not use any of the vulnerable functions so it not
-          susceptible to this vulnerability.
-        expires: 2023-06-28T13:39:03.244Z
-        created: 2022-12-13T13:39:03.262Z
+          CVE-2020-29582: This vulnerability relates to information exposure via
+          creation of temporary files (via Kotlin functions) with insecure
+          permissions. Corda does not use any of the vulnerable functions so it
+          not susceptible to this vulnerability.
+        expires: 2029-08-01T00:00:00.000Z
+        created: 2026-06-23T08:50:38.215Z
   SNYK-JAVA-ORGYAML-3016888:
     - '*':
         reason: >-
@@ -241,4 +241,106 @@ ignore:
           not susceptible to this vulnerability
         expires: 2023-06-28T12:08:51.553Z
         created: 2023-01-09T12:08:51.571Z
+  SNYK-JAVA-ORGAPACHEACTIVEMQ-15423960:
+    - '*':
+        reason: >-
+          CVE-2026-27446: This vulnerability is reported for Apache Artemis.
+          This version Corda is built with an R3-specific version of Artemis
+          that resolves this issue.
+        expires: 2029-08-01T00:00:00.000Z
+        created: 2026-06-23T08:50:17.384Z
+  SNYK-JAVA-ORGAPACHEACTIVEMQ-9598037:
+    - '*':
+        reason: >-
+          CVE-2025-27427: This vulnerability allows a user with queue creation
+          permissions to improperly modify an addresses routing type without
+          having address-creation permissions. In Corda Artemis is embedded or
+          used in tightly controlled external configurations accessible only to
+          trusted Corda nodes under authenticated conditions. There are no
+          untrusted users with the permissions needed to exploit the
+          vulnerability. Therefore Corda is not susceptible to this
+          vulnerability.
+        expires: 2029-08-01T00:00:00.000Z
+        created: 2026-06-23T08:50:19.626Z
+  SNYK-JAVA-ORGAPACHEACTIVEMQ-9689862:
+    - '*':
+        reason: >-
+          CVE-2025-27391: This vulnerability allows sensitive information to be
+          written to the Corda log file when debugging is enabled. Debug logging
+          is an exceptional (and temporary) configuration, and the expectation
+          is that logs are only accessed by trusted administrators.
+        expires: 2029-08-01T00:00:00.000Z
+        created: 2026-06-23T08:50:21.967Z
+  SNYK-JAVA-ORGAPACHEACTIVEMQ-9689863:
+    - '*':
+        reason: >-
+          CVE-2025-27391: This vulnerability allows sensitive information to be
+          written to the Corda log file when debugging is enabled. Debug logging
+          is an exceptional (and temporary) configuration, and the expectation
+          is that logs are only accessed by trusted administrators.
+        expires: 2029-08-01T00:00:00.000Z
+        created: 2026-06-23T08:50:24.062Z
+  SNYK-JAVA-ORGAPACHEACTIVEMQ-9689864:
+    - '*':
+        reason: >-
+          CVE-2025-27391: This vulnerability allows sensitive information to be
+          written to the Corda log file when debugging is enabled. Debug logging
+          is an exceptional (and temporary) configuration, and the expectation
+          is that logs are only accessed by trusted administrators.
+        expires: 2029-08-01T00:00:00.000Z
+        created: 2026-06-23T08:50:26.458Z
+  SNYK-JAVA-ORGAPACHELOGGINGLOG4J-14532782:
+    - '*':
+        reason: >-
+          CVE-2025-68161: This is a Log4j vulnerbility that can occur when the
+          node's logging is configured with a Socket Appender - the appender
+          does not perform TLS hostname verification of the peer certificate.
+          The Log4j package cannot be upgraded for this version of Corda. The
+          default Log4j configuration provided in the Corda node does not
+          include any Socket Appenders. If a node has a custom Log4j
+          configuration that includes Socket Appenders then to mitigate against
+          this vulnerability the Socket Appender definitions may be configured
+          to use a private or restricted trust root to limit the set of trusted
+          certificates.
+        expires: 2029-08-01T00:00:00.000Z
+        created: 2026-06-23T08:50:28.772Z
+  SNYK-JAVA-ORGAPACHELOGGINGLOG4J-15967727:
+    - '*':
+        reason: >-
+          CVE-2026-34477: This is a Log4j vulnerbility that can occur when the
+          node's logging is configured with a Socket Appender - the appender
+          does not perform TLS hostname verification of the peer certificate.
+          The Log4j package cannot be upgraded for this version of Corda. The
+          default Log4j configuration provided in the Corda node does not
+          include any Socket Appenders. If a node has a custom Log4j
+          configuration that includes Socket Appenders then to mitigate against
+          this vulnerability the Socket Appender definitions may be configured
+          to use a private or restricted trust root to limit the set of trusted
+          certificates.
+        expires: 2029-08-01T00:00:00.000Z
+        created: 2026-06-23T08:50:31.391Z
+  SNYK-JAVA-ORGAPACHELOGGINGLOG4J-15967769:
+    - '*':
+        reason: >-
+          CVE-2026-34480: This is a Log4j vulnerbility that can occur when the
+          node's logging is configured to generate XML-formatted log messages.
+          The Log4j package cannot be upgraded for this version of Corda. The
+          default Log4j configuration provided in the Corda node does not
+          include configuration for XML formatted log messages. If a node has a
+          custom Log4j configuration that specifies XML output then CorDapps
+          need to be sure to only include characters permitted in XML 1.0.
+        expires: 2029-08-01T00:00:00.000Z
+        created: 2026-06-23T08:50:33.617Z
+  SNYK-JAVA-ORGAPACHELOGGINGLOG4J-15967804:
+    - '*':
+        reason: >-
+          CVE-2026-34479: This is a Log4j vulnerbility that can occur when the
+          node's logging is configured to generate XML-formatted log messages.
+          The Log4j package cannot be upgraded for this version of Corda. The
+          default Log4j configuration provided in the Corda node does not
+          include configuration for XML formatted log messages. If a node has a
+          custom Log4j configuration that specifies XML output then CorDapps
+          need to be sure to only include characters permitted in XML 1.0.
+        expires: 2029-08-01T00:00:00.000Z
+        created: 2026-06-23T08:50:36.025Z
 patch: {}

--- a/build.gradle
+++ b/build.gradle
@@ -262,6 +262,16 @@ allprojects {
             allWarningsAsErrors = false
         }
     }
+
+    configurations {
+        all {
+            resolutionStrategy {
+                // These dependencies are forced in-sync with Corda OS 4.11.
+                force "org.apache.commons:commons-configuration2:$commonsConfiguration2Version"
+                force "org.apache.commons:commons-dbcp2:$commonsDbcpVersion"
+            }
+        }
+    }
 }
 
 artifactory {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ cordaOpenSourceReleaseGroup=net.corda
 cordaPlatformVersion=11
 
 kotlinVersion=1.2.71
-crashVersion=1.7.8
+crashVersion=1.7.9
 jansiVersion=1.18
 log4jVersion=2.17.1
 slf4jVersion=1.7.30
@@ -29,3 +29,6 @@ mockitoKotlinVersion=1.6.0
 
 artifactoryPluginVersion=4.16.1
 artifactoryContextUrl=https://software.r3.com/artifactory
+
+commonsConfiguration2Version=2.15.0
+commonsDbcpVersion=2.14.0


### PR DESCRIPTION
Dependency and waiver updates to address security issues:

Artemis waivers
As per Corda ENT 4.11
CVE-2026-27446 Missing Authentication for Critical Function
CVE-2025-27427 Incorrect Authorization
CVE-2025-27391 Insertion of Sensitive Information into Log File

Force commons-configuration2 version for all sub-modules
As per Corda ENT 4.11
CVE-2026-45205 Uncontrolled Recursion
CVE-2022-33980 Arbitrary Code Execution
CVE-2024-29133 Out-of-Bounds Write
CVE-2024-29131 Out-of-Bounds Write

Force commons-dbcp2 version for all sub-modules
As per Corda ENT 4.11
CWE-200 Information Exposure

Log4j waivers
As per Corda ENT 4.11
CVE-2025-68161 Improper Validation of Certificate with Host Mismatch
CVE-2026-34477 Improper Validation of Certificate with Host Mismatch
CVE-2026-34480 Improper Encoding or Escaping of Output
CVE-2026-34479 Improper Encoding or Escaping of Output

Corda crash upgrade
CVE-2026-47065 Deserialization of Untrusted Data

Kotlin stdlib waivers - expiry date extension
CVE-2020-29582 Information Exposure
CVE-2022-24329 Improper Locking