### PR TITLE
ENT-15725 - Forced upgrade netty to version 4.1.136.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,20 @@ allprojects {
                     if (details.requested.group == 'org.apache.sshd' && details.requested.name == 'sshd-core') {
                         details.useVersion sshdCoreVersion
                     }
+
+                    // SNYK-JAVA-IONETTY-18170202 / CVE-2026-55833
+                    // SNYK-JAVA-IONETTY-18170204 / CVE-2026-56819
+                    // SNYK-JAVA-IONETTY-18170213 / CVE-2026-56745
+                    // SNYK-JAVA-IONETTY-18170206 / CVE-2026-56746
+                    // Vulnerability in io.netty:netty-codec-haproxy, which is a transitive dependency
+                    // of artemis-server@2.55.0
+                    if (details.requested.group == 'io.netty' && details.requested.name.startsWith('netty-')) {
+                        if (details.requested.name.startsWith('netty-tcnative')) {
+                            details.useVersion tcnativeVersion
+                        } else {
+                            details.useVersion nettyVersion
+                        }
+                    }
                 }
             }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,3 +38,5 @@ gradlePluginsVersion=5.1.3
 mockitoVersion=5.5.0
 mockitoKotlinVersion=5.1.0
 internalPublishVersion=1.+
+nettyVersion=4.1.136.Final
+tcnativeVersion=2.0.74.Final


### PR DESCRIPTION
Forced upgrade netty to resolve the following vulnerabilities : CVE-2026-55833, CVE-2026-56819, CVE-2026-56745, CVE-2026-56746